### PR TITLE
Push checking down into `send` and `end`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/License-MIT-00CCFF.svg?style=flat-square) 
+![](https://img.shields.io/badge/License-MIT-00CCFF.svg?style=flat-square)
 ![](https://img.shields.io/badge/superagent--mock-JS-FF0066.svg?style=flat-square)
 [![NPM Downloads](http://img.shields.io/npm/dm/superagent-mock.svg?style=flat-square)](https://www.npmjs.org/package/superagent-mock)
 [![Build Status](http://img.shields.io/travis/M6Web/superagent-mock.svg?style=flat-square)](https://travis-ci.org/M6Web/superagent-mock)
@@ -54,27 +54,27 @@ module.exports = [
      */
     fixtures: function (match, params) {
       /**
-       * example: 
+       * example:
        *   request.get('https://error.example/404').end(function(err, res){
        *     console.log(err); // 404
-       *   }) 
-       */ 
+       *   })
+       */
       if (match[1] === '404') {
         throw new Error(404);
       }
 
       /**
-       * example: 
+       * example:
        *   request.get('https://error.example/200').end(function(err, res){
        *     console.log(res.body); // "Data fixtures"
        *   })
        */
 
       /**
-       * example: 
+       * example:
        *   request.get('https://domain.send.example/').send({superhero: "me"}).end(function(err, res){
        *     console.log(res.body); // "Data fixtures - superhero:me"
-       *   }) 
+       *   })
        */
       if(params["superhero"]) {
         return 'Data fixtures - superhero:' + params["superhero"];
@@ -111,7 +111,7 @@ require('superagent-mock')(request, config);
 
 ## Supported Methods
 
-GET, POST and PUT requests are mocked.
+All methods are supported.
 
 ## Tests
 
@@ -122,7 +122,7 @@ To check code style: `npm run lint`.
 
 ## Credits
 
-Developped by the [Cytron Team](http://cytron.fr/) of [M6 Web](http://tech.m6web.fr/).   
+Developped by the [Cytron Team](http://cytron.fr/) of [M6 Web](http://tech.m6web.fr/).
 Tested with [nodeunit](https://github.com/caolan/nodeunit).
 
 ## License

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -12,7 +12,7 @@ module.exports = mock;
  */
 function mock (superagent, config) {
   var Request = superagent.Request;
-  var parsers = [];
+  var parsers = Object.create(null);
 
   /**
    * Keep the default methods
@@ -27,47 +27,23 @@ function mock (superagent, config) {
    * Attempt to match url against the patterns in fixtures.
    */
   function testUrlForPatterns(url) {
-    if (parsers[url]) { return; }
+    if (parsers.hasOwnProperty(url)) { return parsers[url]; }
 
     var match = config.filter(function (parser) {
       return new RegExp(parser.pattern, 'g').test(url);
     })[0] || null;
 
-    if (match) {
-      parsers[url] = match;
-    }
+    parsers[url] = match;
+    
+    return match;
   }
-
-  /**
-   * Override get function
-   */
-  superagent.get = function (url, data, fn) {
-    testUrlForPatterns(url);
-    return parsers[url] ? superagent('GET', url, data, fn) : oldGet.call(this, url, data, fn);
-  };
-
-  /**
-   * Override post function
-   */
-   superagent.post = function (url, data, fn) {
-     testUrlForPatterns(url);
-     return parsers[url] ? superagent('POST', url, data, fn) : oldPost.call(this, url, data, fn);
-   };
-
-  /**
-   * Override put function
-   */
-   superagent.put = function (url, data, fn) {
-     testUrlForPatterns(url);
-     return parsers[url] ? superagent('PUT', url, data, fn) : oldPut.call(this, url, data, fn);
-   };
 
   /**
    * Override send function
    */
   Request.prototype.send = function (data) {
 
-    var parser = parsers[this.url];
+    var parser = testUrlForPatterns(this.url);
     if (parser) {
       this.params = data;
 
@@ -102,7 +78,7 @@ function mock (superagent, config) {
       path += (~path.indexOf('?') ? '&' : '?') + querystring;
     }
 
-    var parser = parsers[this.url];
+    var parser = testUrlForPatterns(this.url);
 
     if (parser) {
       var match = new RegExp(parser.pattern, 'g').exec(path);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -24,7 +24,9 @@ function mock (superagent, config) {
    * Attempt to match url against the patterns in fixtures.
    */
   function testUrlForPatterns(url) {
-    if (parsers[url]) { return parsers[url]; }
+    if (parsers[url]) {
+      return parsers[url];
+    }
 
     var match = config.filter(function (parser) {
       return new RegExp(parser.pattern, 'g').test(url);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -24,7 +24,7 @@ function mock (superagent, config) {
    * Attempt to match url against the patterns in fixtures.
    */
   function testUrlForPatterns(url) {
-    if (parsers.hasOwnProperty(url)) { return parsers[url]; }
+    if (parsers[url]) { return parsers[url]; }
 
     var match = config.filter(function (parser) {
       return new RegExp(parser.pattern, 'g').test(url);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -17,9 +17,6 @@ function mock (superagent, config) {
   /**
    * Keep the default methods
    */
-  var oldGet = superagent.get;
-  var oldPost = superagent.post;
-  var oldPut = superagent.put;
   var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
 
@@ -34,7 +31,7 @@ function mock (superagent, config) {
     })[0] || null;
 
     parsers[url] = match;
-    
+
     return match;
   }
 


### PR DESCRIPTION
This is a compatibility request from lightsofapollo/superagent-promise. We provide our own implementations of `get`, `put`, and `post` and so cannot take advantage of this module.

Since you call `testUrlForPatterns` before every `get`, `put`, or `post` pushing the testing down shouldn't affect performance much (unless you have a really `option` heavy workload... 

Also changing the memoization technique should net performance gains for non-mocked URLs.