### PR TITLE
Also apply 'sugar' behavior on error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module.exports = [
        * Returning error codes example:
        *   request.get('https://domain.example/404').end(function(err, res){
        *     console.log(err); // 404
+       *     console.log(res.notFound); // true
        *   })
        */
       if (match[1] === '/404') {

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -13,6 +13,7 @@ module.exports = mock;
 function mock (superagent, config) {
   var Request = superagent.Request;
   var parsers = Object.create(null);
+  var response = {};
 
   /**
    * Keep the default methods
@@ -95,21 +96,21 @@ function mock (superagent, config) {
         var fixtures = parser.fixtures(match, this.params, this.headers);
         fn(null, parsers[this.url].callback(match, fixtures));
       } catch(err) {
-        var response = new superagent.Response({
+        response = new superagent.Response({
           res: {
             headers: {},
-            setEncoding: function(){},
-            on: function(){}
+            setEncoding: function (){},
+            on: function (){}
           },
           req: {
-            method: function(){}
+            method: function (){}
           },
           xhr: {
             responseType: '',
-            getAllResponseHeaders: function() {return 'a header'},
-            getResponseHeader: function() {return 'a header'}
+            getAllResponseHeaders: function () {return 'a header';},
+            getResponseHeader: function () {return 'a header';}
           }
-        })
+        });
         response.setStatusProperties(err.message);
         fn(err, response);
       }

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -95,7 +95,23 @@ function mock (superagent, config) {
         var fixtures = parser.fixtures(match, this.params, this.headers);
         fn(null, parsers[this.url].callback(match, fixtures));
       } catch(err) {
-        fn(err, undefined);
+        var response = new superagent.Response({
+          res: {
+            headers: {},
+            setEncoding: function(){},
+            on: function(){}
+          },
+          req: {
+            method: function(){}
+          },
+          xhr: {
+            responseType: '',
+            getAllResponseHeaders: function() {return 'a header'},
+            getResponseHeader: function() {return 'a header'}
+          }
+        })
+        response.setStatusProperties(err.message);
+        fn(err, response);
       }
     } else {
       oldEnd.call(this, fn);

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -34,7 +34,7 @@ module.exports = [
     pattern: 'https://error.example/(\\w+)',
     fixtures: function (match) {
       var code = (match || [])[1] || 404;
-      var newErr = new Error(http.STATUS_CODES[code]);
+      var newErr = new Error(parseInt(code));
       newErr.response = http.STATUS_CODES[code];
       newErr.status = code;
       throw newErr;

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -109,12 +109,24 @@ module.exports = function (request, config) {
           });
       },
 
-      'catches error and response it': function (test) {
+      'catches not found error and response it': function (test) {
         request.get('https://error.example/404')
           .end(function (err, result) {
             test.notEqual(err, null);
             test.equal(err.status, 404);
             test.equal(err.response, http.STATUS_CODES[404]);
+            test.ok(result.notFound)
+            test.done();
+          });
+      },
+
+      'catches unauthorized error and response it': function (test) {
+        request.get('https://error.example/401')
+          .end(function (err, result) {
+            test.notEqual(err, null);
+            test.equal(err.status, 401);
+            test.equal(err.response, http.STATUS_CODES[401]);
+            test.ok(result.unauthorized)
             test.done();
           });
       },
@@ -232,12 +244,24 @@ module.exports = function (request, config) {
           });
       },
 
-      'catches error and response it': function (test) {
+      'catches not found error and response it': function (test) {
         request.post('https://error.example/404')
           .end(function (err, result) {
             test.notEqual(err, null);
             test.equal(err.status, 404);
             test.equal(err.response, http.STATUS_CODES[404]);
+            test.ok(result.notFound)
+            test.done();
+          });
+      },
+
+      'catches unauthorized error and response it': function (test) {
+        request.post('https://error.example/401')
+          .end(function (err, result) {
+            test.notEqual(err, null);
+            test.equal(err.status, 401);
+            test.equal(err.response, http.STATUS_CODES[401]);
+            test.ok(result.unauthorized)
             test.done();
           });
       },
@@ -344,12 +368,24 @@ module.exports = function (request, config) {
           });
       },
 
-      'catches error and response it': function (test) {
+      'catches not found error and response it': function (test) {
         request.put('https://error.example/404')
           .end(function (err, result) {
             test.notEqual(err, null);
             test.equal(err.status, 404);
             test.equal(err.response, http.STATUS_CODES[404]);
+            test.ok(result.notFound)
+            test.done();
+          });
+      },
+
+      'catches unauthorized error and response it': function (test) {
+        request.put('https://error.example/401')
+          .end(function (err, result) {
+            test.notEqual(err, null);
+            test.equal(err.status, 401);
+            test.equal(err.response, http.STATUS_CODES[401]);
+            test.ok(result.unauthorized)
             test.done();
           });
       },


### PR DESCRIPTION
I also needed the 'sugar' that superagent applies to responses on error. So when superagent receives a 401, it also sets unauthorised to true in the response object. Superagent-mock didn't recreate this behaviour as far as I could see.

This recreates that, by making a fake response object and getting it to apply the right properties to that object based on the error that superagent-mock catches.

It only applies it on errors though (so in the catch clause of the fixture parser). 