### PR TITLE
Add explicit support for request methods (GET, POST, DELETE ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ require('superagent-mock')(request, config);
 
 All request methods are supported (get, put, post, etc.).
 
-Each request method mock have to be declared in the config file.
+Each request method mock have to be declared in the config file. Otherwise, the `callback` method is used.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,26 @@ module.exports = [
     },
 
     /**
-     * returns the result of the request
+     * returns the result of the GET request
      *
      * @param match array Result of the resolution of the regular expression
      * @param data  mixed Data returns by `fixtures` attribute
      */
-    callback: function (match, data) {
+    get: function (match, data) {
       return {
         body: data
+      };
+    },
+
+    /**
+     * returns the result of the POST request
+     *
+     * @param match array Result of the resolution of the regular expression
+     * @param data  mixed Data returns by `fixtures` attribute
+     */
+    post: function (match, data) {
+      return {
+        code: 201
       };
     }
   },
@@ -127,6 +139,8 @@ require('superagent-mock')(request, config);
 ## Supported methods
 
 All request methods are supported (get, put, post, etc.).
+
+Each request method mock have to be declared in the config file.
 
 ## Tests
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -94,7 +94,9 @@ function mock (superagent, config) {
 
       try {
         var fixtures = parser.fixtures(match, this.params, this.headers);
-        fn(null, parsers[this.url].callback(match, fixtures));
+        var method = this.method.toLocaleLowerCase();
+
+        fn(null, parsers[this.url][method](match, fixtures));
       } catch(err) {
         response = new superagent.Response({
           res: {

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -95,8 +95,9 @@ function mock (superagent, config) {
       try {
         var fixtures = parser.fixtures(match, this.params, this.headers);
         var method = this.method.toLocaleLowerCase();
+        var parserMethod = parsers[this.url][method] ? parsers[this.url][method] : parsers[this.url].callback;
 
-        fn(null, parsers[this.url][method](match, fixtures));
+        fn(null, parserMethod(match, fixtures));
       } catch(err) {
         response = new superagent.Response({
           res: {

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -96,5 +96,14 @@ module.exports = [
     put: function (match, data) {
       return {match: match, data: data};
     }
+  },
+  {
+    pattern: 'https://callback.method.example',
+    fixtures: function () {
+      return 'Fixture !';
+    },
+    callback: function (match, data) {
+      return {match: match, data: data};
+    }
   }
-  ];
+];

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -8,8 +8,14 @@ module.exports = [
     fixtures: function () {
       return 'Fixture !';
     },
-    callback: function (match, data) {
-      return {match: match, data: data};
+    get: function (match, data) {
+      return {match: match, data: data, code: 200};
+    },
+    post: function (match, data) {
+      return {match: match, data: data, code: 201};
+    },
+    put: function (match, data) {
+      return {match: match, data: data, code: 201};
     }
   },
   {
@@ -17,7 +23,13 @@ module.exports = [
     fixtures: function () {
       return 'Fixture !';
     },
-    callback: function (match, data) {
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
       return {match: match, data: data};
     }
   },
@@ -26,7 +38,13 @@ module.exports = [
     fixtures: function (match) {
       return match && match[1];
     },
-    callback: function (match, data) {
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
       return {match: match, data: data};
     }
   },
@@ -39,7 +57,13 @@ module.exports = [
       newErr.status = code;
       throw newErr;
     },
-    callback: function (match, data) {
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
       return {match: match, data: data};
     }
   },
@@ -48,7 +72,13 @@ module.exports = [
     fixtures: function (match, params) {
       return 'Fixture ! - superhero:' + params.superhero;
     },
-    callback: function (match, data) {
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
       return {match: match, data: data};
     }
   },
@@ -57,7 +87,13 @@ module.exports = [
     fixtures: function (match, params, headers) {
       return 'your token: ' + headers['Authorization']
     },
-    callback: function (match, data) {
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
       return {match: match, data: data};
     }
   }

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -23,6 +23,7 @@ module.exports = function (request, config) {
           test.ok(!err);
           test.equal(result.match[1], '666');
           test.equal(result.data, 'Fixture !');
+          test.equal(result.code, 200);
           test.done();
         });
       },
@@ -158,6 +159,7 @@ module.exports = function (request, config) {
           test.ok(!err);
           test.equal(result.match[1], '666');
           test.equal(result.data, 'Fixture !');
+          test.equal(result.code, 201);
           test.done();
         });
       },
@@ -282,6 +284,7 @@ module.exports = function (request, config) {
           test.ok(!err);
           test.equal(result.match[1], '666');
           test.equal(result.data, 'Fixture !');
+          test.equal(result.code, 201);
           test.done();
         });
       },

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -28,6 +28,14 @@ module.exports = function (request, config) {
         });
       },
 
+      'matching simple request with default callback': function (test) {
+        request.get('https://callback.method.example').end(function (err, result) {
+          test.ok(!err);
+          test.equal(result.data, 'Fixture !');
+          test.done();
+        });
+      },
+
       'unmatching simple request': function (test) {
         request.get('https://dummy.domain/666').end(function (err, result) {
           test.ok(!err);
@@ -164,6 +172,14 @@ module.exports = function (request, config) {
         });
       },
 
+      'matching simple request with default callback': function (test) {
+        request.post('https://callback.method.example').end(function (err, result) {
+          test.ok(!err);
+          test.equal(result.data, 'Fixture !');
+          test.done();
+        });
+      },
+
       'unmatching simple request': function (test) {
         request.post('https://dummy.domain/666').end(function (err, result) {
           test.ok(!err);
@@ -285,6 +301,14 @@ module.exports = function (request, config) {
           test.equal(result.match[1], '666');
           test.equal(result.data, 'Fixture !');
           test.equal(result.code, 201);
+          test.done();
+        });
+      },
+
+      'matching simple request with default callback': function (test) {
+        request.put('https://callback.method.example').end(function (err, result) {
+          test.ok(!err);
+          test.equal(result.data, 'Fixture !');
           test.done();
         });
       },


### PR DESCRIPTION
The 'callback' method in the superagent-mock-config is replaced by one
method for each request methods.

``` js
module.exports = [
  {
    pattern: 'https://domain.example/(\\w+)',
    fixtures: function () {
      return 'Fixture !';
    },
    get: function (match, data) {
      return {match: match, data: data, code: 200};
    },
    post: function (match, data) {
      return {match: match, data: data, code: 201};
    }
  }
];
```

Tests and README file have been udated.