### PR TITLE
Add method to unmock

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,13 @@ Then use the plugin:
 var request = require('superagent');
 var config = require('./superagent-mock-config');
 
-require('superagent-mock')(request, config);
+//Before tests
+var superagentMock = require('superagent-mock')(request, config);
+
+...
+
+//After tests
+superagentMock.unset();
 ```
 
 ## Supported methods

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -18,6 +18,7 @@ function mock (superagent, config) {
   /**
    * Keep the default methods
    */
+  var oldSet = Request.prototype.set;
   var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
 
@@ -119,6 +120,14 @@ function mock (superagent, config) {
       }
     } else {
       oldEnd.call(this, fn);
+    }
+  };
+
+  return {
+    unset: function () {
+      Request.prototype.send = oldSend;
+      Request.prototype.set = oldSet;
+      Request.prototype.end = oldEnd;
     }
   };
 }

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -3,6 +3,8 @@
 var http = require('http');
 
 module.exports = function (request, config) {
+  var superagentMock;
+
   return {
 
     'setUp': function (go) {
@@ -12,11 +14,28 @@ module.exports = function (request, config) {
       };
 
       // Init module
-      require('./../../lib/superagent-mock')(request, config);
+      superagentMock = require('./../../lib/superagent-mock')(request, config);
 
       go();
     },
 
+    tearDown: function (go) {
+      superagentMock.unset();
+
+      go();
+    },
+
+    'Lib': {
+      'handle reset of mock': function (test) {
+        superagentMock.unset();
+
+        request.get('https://callback.method.example').end(function (err, result) {
+          test.ok(!err);
+          test.equal(result, 'Real call done');
+          test.done();
+        });
+      }
+    },
     'Method GET': {
       'matching simple request': function (test) {
         request.get('https://domain.example/666').end(function (err, result) {


### PR DESCRIPTION
What do you think about possibility to unmock superagent request? I like to write mocked http response just before asserters to make it clean, but this approach require cleanup method.