### PR TITLE
Added the option to set the text and body on erroneus responses

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -110,7 +110,7 @@ function mock (superagent, config) {
             headers: {},
             setEncoding: function (){},
             on: function (){},
-            body: err.responseBody || {},
+            body: err.responseBody || {}
           },
           req: {
             method: function (){}

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -109,15 +109,18 @@ function mock (superagent, config) {
           res: {
             headers: {},
             setEncoding: function (){},
-            on: function (){}
+            on: function (){},
+            body: err.responseBody || {},
           },
           req: {
             method: function (){}
           },
+
           xhr: {
             responseType: '',
+            responseText: err.responseText || '',
             getAllResponseHeaders: function () {return 'a header';},
-            getResponseHeader: function () {return 'a header';}
+            getResponseHeader: function () {return err.responseHeader || 'a header';}
           }
         });
         response.setStatusProperties(err.message);

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -68,6 +68,23 @@ module.exports = [
     }
   },
   {
+    pattern: 'https://validation.example',
+    fixtures: function (match, params, headers) {
+      var error = new Error( 422 );
+      var code = (match || [])[1] || 422;
+      var newErr = new Error(parseInt(code));
+      newErr.response = http.STATUS_CODES[code];
+      newErr.status = code;
+      newErr.responseHeader = 'application/json';
+      newErr.responseText = '{"password": "missing"}';
+      newErr.responseBody = { password: 'missing' };
+      throw newErr;
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
     pattern: 'https://domain.send.example/(\\w+)',
     fixtures: function (match, params) {
       return 'Fixture ! - superhero:' + params.superhero;

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -300,7 +300,18 @@ module.exports = function (request, config) {
           });
       },
 
-      'catches unauthorized error and response it': function (test) {
+      'catches validation error and response it': function (test) {
+        request.post('https://validation.example')
+          .end(function (err, result) {
+            test.notEqual(err, null);
+            test.equal(err.status, 422);
+            test.equal(err.response, http.STATUS_CODES[422]);
+            test.deepEqual(result.body, {password: 'missing'});
+            test.done();
+          });
+      },
+
+      'catches validation errors and sets text': function (test) {
         request.post('https://error.example/401')
           .end(function (err, result) {
             test.notEqual(err, null);


### PR DESCRIPTION
Use like this:

```javascript
fixtures: function (match, params, headers) {
      var error = new Error( 422 );
      var code = (match || [])[1] || 422;
      var newErr = new Error(parseInt(code));
      newErr.response = http.STATUS_CODES[code];
      newErr.status = code;
      newErr.responseHeader = 'application/json';
      newErr.responseText = '{"password": "missing"}';
      newErr.responseBody = { password: 'missing' }; // only needed on server/isomorphic
      throw newErr;
},
```

Fix #16 