### PR TITLE
Add support for chained calls to set()

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -56,13 +56,26 @@ function mock (superagent, config) {
   };
 
   /**
+   * Returns true if `obj` is an object.
+   */
+  function isObject(obj) {
+    return obj === Object(obj);
+  }
+
+  /**
    * Override set function
    */
-  Request.prototype.set = function (headers) {
+  Request.prototype.set = function (field, val) {
     var parser = testUrlForPatterns(this.url);
     if (parser) {
-      this.headers = headers;
-
+      if (isObject(field)) {
+        for (var key in field) {
+          this.set(key, field[key]);
+        }
+      } else {
+        this.headers = this.headers || {};
+        this.headers[field] = val;
+      }
       return this;
     } else {
       return oldSet.apply(this, arguments);

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -98,6 +98,21 @@ module.exports = [
     }
   },
   {
+    pattern: 'https://multiple-headers.example',
+    fixtures: function (match, params, headers) {
+      return 'X-API-Key: ' + headers['X-API-Key'] + '; Content-Type: ' + headers['Content-Type']
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
     pattern: 'https://callback.method.example',
     fixtures: function () {
       return 'Fixture !';

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -319,6 +319,17 @@ module.exports = function (request, config) {
             test.equal(result.data, 'your token: valid_token');
             test.done();
           });
+      },
+
+      'setting multiple headers': function (test) {
+        request.post('https://multiple-headers.example/')
+          .set('X-API-Key', 'foobar')
+          .set('Content-Type', 'application/json')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result.data, 'X-API-Key: foobar; Content-Type: application/json');
+            test.done();
+          });
       }
     },
     'Method PUT': {


### PR DESCRIPTION
This commit adds support for chained calls to set(), such that request headers can be specified one at a time (as is possible for superagent). This addresses issue #17.