### PR TITLE
Mock out request.abort

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -147,7 +147,7 @@ function mock (superagent, config) {
     this.req = {abort: function () {}};
 
     oldAbort.bind(this)();
-  }
+  };
 
   return {
     unset: function () {

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -21,6 +21,7 @@ function mock (superagent, config) {
   var oldSet = Request.prototype.set;
   var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
+  var oldAbort = Request.prototype.abort;
 
   /**
    * Attempt to match url against the patterns in fixtures.
@@ -141,11 +142,19 @@ function mock (superagent, config) {
     }
   };
 
+  Request.prototype.abort = function () {
+    this.xhr = {abort: function () {}};
+    this.req = {abort: function () {}};
+
+    oldAbort.bind(this)();
+  }
+
   return {
     unset: function () {
       Request.prototype.send = oldSend;
       Request.prototype.set = oldSet;
       Request.prototype.end = oldEnd;
+      Request.prototype.abort = oldAbort;
     }
   };
 }

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -186,7 +186,14 @@ module.exports = function (request, config) {
             test.equal(result.data, 'your token: valid_token');
             test.done();
           });
+      },
+
+      'aborting simple request': function (test) {
+        request.get('https://domain.example/666').abort();
+
+        test.done();
       }
+
     },
     'Method POST': {
       'matching simple request': function (test) {
@@ -330,6 +337,12 @@ module.exports = function (request, config) {
             test.equal(result.data, 'X-API-Key: foobar; Content-Type: application/json');
             test.done();
           });
+      },
+
+      'aborting simple request': function (test) {
+        request.post('https://domain.example/666').abort();
+
+        test.done();
       }
     },
     'Method PUT': {
@@ -454,6 +467,12 @@ module.exports = function (request, config) {
             test.done();
           });
       },
+
+      'aborting simple request': function (test) {
+        request.put('https://domain.example/666').abort();
+
+        test.done();
+      }
     },
     'Header setting': {
       'setting mocked headers': function (test) {


### PR DESCRIPTION
In order to use this module to create a mocked out test for https://github.com/cyclejs/cycle-http-driver, I had to add support for calling `abort` on the request.

Thought it might be useful to include.