### PR TITLE
Return request on end, just like superagent actually does.

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -87,7 +87,6 @@ function mock (superagent, config) {
    * Override end function
    */
   Request.prototype.end = function (fn) {
-
     var path = this.url;
     var querystring = '';
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -140,6 +140,8 @@ function mock (superagent, config) {
         response.setStatusProperties(err.message);
         fn(err, response);
       }
+
+      return this;
     } else {
       oldEnd.call(this, fn);
     }

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -507,6 +507,17 @@ module.exports = function (request, config) {
             test.done();
           });
       }
+    },
+    'end': {
+      'returns request object': function (test) {
+        var requestObject = request.get('https://domain.example/test')
+                                   .set({header: "value"})
+                                   .end(function(err, result){});
+
+        test.equal(requestObject.url, 'https://domain.example/test');
+        test.deepEqual(requestObject.headers, { header: 'value' }),
+        test.done();
+      }
     }
   };
 };


### PR DESCRIPTION
I needed to check if I set some headers correctly in my tests.

I noticed that superagent actually returns the request object in its own `end` call: https://github.com/visionmedia/superagent/blob/b91a26fb4d8acf28534ac2cdd0bb3ce4a6f17498/lib/client.js#L813

Superagent-mock does not do this. 

That means I couldn't inspect the request object I had made to ensure that some code of mine was setting headers correctly on the superagent request object.

This changes superagent-mock so that it also returns the request object for mocked requests.

Does it need tests? Let me know. :+1: 
