### PR TITLE
Fix tests

### DIFF
--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -4,7 +4,7 @@
 var component = require('component-as-module');
 
 // Get the "client" version of superagent
-var request = component('node_modules/superagent', function (loader) {
+var request = component('tests/support', function (loader) {
   loader.register('component-emitter', function () {
     return require('superagent/node_modules/component-emitter');
   });

--- a/tests/support/component.json
+++ b/tests/support/component.json
@@ -1,0 +1,14 @@
+{
+  "name": "superagent",
+  "scripts": [
+    "../../node_modules/superagent/lib/client.js",
+    "../../node_modules/superagent/lib/is-object.js",
+    "../../node_modules/superagent/lib/request-base.js",
+    "../../node_modules/superagent/lib/request.js"
+  ],
+  "main": "../../node_modules/superagent/lib/client.js",
+  "dependencies": {
+    "component/emitter": "*",
+    "component/reduce": "*"
+  }
+}


### PR DESCRIPTION
@oziks j'ai corrigé les tests en "fakant" le `component.json`de superagent qui n'est plus bon au vu des derniers changements qu'ils ont fait dans la lib. Si on veut faire propre, `component` est un truc déprécié, il faudrait tester la version cliente de `superagent` autrement mais je ne sais pas trop comment (le charger dans un browser par exemple...). Si t'as une solution, je prends 😺 