### PR TITLE
Add logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,37 @@ All request methods are supported (get, put, post, etc.).
 
 Each request method mock have to be declared in the config file. Otherwise, the `callback` method is used.
 
+## Logging
+
+You can monitor each call, that has been intercepted by superagent-mock or not, by passing a callback function at initialization.
+
+``` js
+// ./server.js file
+var request = require('superagent');
+var config = require('./superagent-mock-config');
+
+var logger = function(log)  {
+  console.log('superagent call', log);
+};
+
+//Before tests
+var superagentMock = require('superagent-mock')(request, config, logger);
+
+...
+
+//After tests
+superagentMock.unset();
+```
+
+The callback function will be called with an object containing the following informations
+ - data : data used with `superagent.send` function
+ - headers : array of headers given by `superagent.set` function
+ - matcher : regex matching the current url which is defined in the provided config
+ - url : url which superagent was called
+ - method : HTTP method used for the call
+ - timestamp : timestamp of the superagent call
+ - mocked : true if the call was mocked by superagent mock, false if it used superagent real methods
+
 ## Tests
 
 To run units tests: `npm test`.

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -9,11 +9,16 @@ module.exports = mock;
 
 /**
  * Installs the `mock` extension to superagent.
+ * @param superagent superagent instance
+ * @param config the mock configuration
+ * @param logger logger callback
  */
-function mock (superagent, config) {
+function mock (superagent, config, logger) {
   var Request = superagent.Request;
   var parsers = Object.create(null);
   var response = {};
+  var currentLog;
+  var logEnabled = !!logger;
 
   /**
    * Keep the default methods
@@ -22,6 +27,26 @@ function mock (superagent, config) {
   var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
   var oldAbort = Request.prototype.abort;
+
+  /**
+   * Get the current log object or create a new one if there isn't any
+   */
+  function getCurrentLog() {
+    if (!currentLog) {
+      currentLog = {};
+    }
+
+    return currentLog;
+  }
+
+  /**
+   * Flush the current log in the logger method and set set it to null
+   */
+  function flushLog() {
+    logger(currentLog);
+
+    currentLog = null;
+  }
 
   /**
    * Attempt to match url against the patterns in fixtures.
@@ -44,6 +69,9 @@ function mock (superagent, config) {
    * Override send function
    */
   Request.prototype.send = function (data) {
+    if (logEnabled) {
+      getCurrentLog().data = data
+    }
 
     var parser = testUrlForPatterns(this.url);
     if (parser) {
@@ -67,6 +95,12 @@ function mock (superagent, config) {
    * Override set function
    */
   Request.prototype.set = function (field, val) {
+    if (logEnabled) {
+      var headerPart = {};
+      headerPart[field] = val;
+      getCurrentLog().headers = (getCurrentLog().headers || []).concat(headerPart)
+    }
+
     var parser = testUrlForPatterns(this.url);
     if (parser) {
       if (isObject(field)) {
@@ -108,6 +142,15 @@ function mock (superagent, config) {
     }
 
     var parser = testUrlForPatterns(this.url);
+
+    if (logEnabled) {
+      getCurrentLog().matcher = parser && parser.pattern;
+      getCurrentLog().mocked = !!parser;
+      getCurrentLog().url = this.url;
+      getCurrentLog().method = this.method;
+      getCurrentLog().timestamp = new Date().getTime();
+      flushLog();
+    }
 
     if (parser) {
       var match = new RegExp(parser.pattern, 'g').exec(path);

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -5,6 +5,11 @@ var http = require('http');
 module.exports = function (request, config) {
   var headers = null;
   var superagentMock;
+  var currentLog = null;
+  var logger = function (log) {
+    currentLog = Object.assign({}, log);
+  };
+
 
   return {
 
@@ -21,7 +26,7 @@ module.exports = function (request, config) {
       };
 
       // Init module
-      superagentMock = require('./../../lib/superagent-mock')(request, config);
+      superagentMock = require('./../../lib/superagent-mock')(request, config, logger);
 
       go();
     },
@@ -29,6 +34,7 @@ module.exports = function (request, config) {
     tearDown: function (go) {
       superagentMock.unset();
       headers = null;
+      currentLog = null;
 
       go();
     },
@@ -151,7 +157,7 @@ module.exports = function (request, config) {
             test.notEqual(err, null);
             test.equal(err.status, 404);
             test.equal(err.response, http.STATUS_CODES[404]);
-            test.ok(result.notFound)
+            test.ok(result.notFound);
             test.done();
           });
       },
@@ -162,7 +168,7 @@ module.exports = function (request, config) {
             test.notEqual(err, null);
             test.equal(err.status, 401);
             test.equal(err.response, http.STATUS_CODES[401]);
-            test.ok(result.unauthorized)
+            test.ok(result.unauthorized);
             test.done();
           });
       },
@@ -504,6 +510,51 @@ module.exports = function (request, config) {
             test.ok(!err);
             test.equal(result, 'Real call done');
             test.deepEqual(headers, {real: "foo"});
+            test.done();
+          });
+      }
+    },
+    'Logger': {
+      'mocked GET': function (test) {
+        request.get('https://domain.example/666').end(function (err, result) {
+          test.ok(!err);
+          test.equal(currentLog.matcher, 'https://domain.example/(\\w+)');
+          test.equal(currentLog.mocked, true);
+          test.equal(currentLog.url, 'https://domain.example/666');
+          test.equal(currentLog.method, 'GET');
+          test.done();
+        });
+      },
+      'mocked PUT': function (test) {
+        request.put('https://domain.example/666').end(function (err, result) {
+          test.ok(!err);
+          test.equal(currentLog.matcher, 'https://domain.example/(\\w+)');
+          test.equal(currentLog.mocked, true);
+          test.equal(currentLog.url, 'https://domain.example/666');
+          test.equal(currentLog.method, 'PUT');
+          test.done();
+        });
+      },
+      'mocked POST': function (test) {
+        request.post('https://domain.example/666', 'foo').end(function (err, result) {
+          test.ok(!err);
+          test.equal(currentLog.matcher, 'https://domain.example/(\\w+)');
+          test.equal(currentLog.data, 'foo');
+          test.equal(currentLog.mocked, true);
+          test.equal(currentLog.url, 'https://domain.example/666');
+          test.equal(currentLog.method, 'POST');
+          test.done();
+        });
+      },
+      'mocked headers': function (test) {
+        request.put('https://authorized.example/')
+          .set({Authorization: "valid_token"})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(currentLog.matcher, 'https://authorized.example');
+            test.equal(currentLog.mocked, true);
+            test.equal(currentLog.url, 'https://authorized.example/');
+            test.equal(currentLog.method, 'PUT');
             test.done();
           });
       }


### PR DESCRIPTION
## Add logging functionalities

Use a callback to log any call made with superagent, mocked or not.
The callback will be called with an object containing information like headers, called url, matching regexp, HTTP method and call timestamp.