### PR TITLE
.end callback should only ever be called once

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -89,6 +89,7 @@ function mock (superagent, config) {
   Request.prototype.end = function (fn) {
     var path = this.url;
     var querystring = '';
+    var error = null;
 
     if (this._query) {
       querystring += this._query.join('&');
@@ -116,8 +117,9 @@ function mock (superagent, config) {
         var method = this.method.toLocaleLowerCase();
         var parserMethod = parsers[this.url][method] ? parsers[this.url][method] : parsers[this.url].callback;
 
-        fn(null, parserMethod(match, fixtures));
+        response = parserMethod(match, fixtures);
       } catch(err) {
+        error = err;
         response = new superagent.Response({
           res: {
             headers: {},
@@ -137,9 +139,9 @@ function mock (superagent, config) {
           }
         });
         response.setStatusProperties(err.message);
-        fn(err, response);
       }
 
+      fn(error, response);
       return this;
     } else {
       oldEnd.call(this, fn);

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -515,7 +515,19 @@ module.exports = function (request, config) {
                                    .end(function(err, result){});
 
         test.equal(requestObject.url, 'https://domain.example/test');
-        test.deepEqual(requestObject.headers, { header: 'value' }),
+        test.deepEqual(requestObject.headers, { header: 'value' });
+        test.done();
+      },
+      'is only called once': function(test) {
+        var calls = 0;
+        test.throws(function() {
+          request.get('https://domain.example/666').end(function (err) {
+            calls++;
+            test.ok(!err);
+            throw new Error('test');
+          });
+        }, Error, 'Should throw internal exception');
+        test.equal(calls, 1);
         test.done();
       }
     }


### PR DESCRIPTION
The problem is that if the callback has a bug and/or throws an exception then it is caught and the callback is called again with error args.  This can then cause issues with things like node-async which does not allow callbacks to be called again.

Superagent-mock should only be catching exceptions internal to itself and not from the callers callback.