### PR TITLE
Add logging functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ Then use the plugin:
 var request = require('superagent');
 var config = require('./superagent-mock-config');
 
-//Before tests
+// Before tests
 var superagentMock = require('superagent-mock')(request, config);
 
 ...
 
-//After tests
+// After tests
 superagentMock.unset();
 ```
 
@@ -147,6 +147,37 @@ superagentMock.unset();
 All request methods are supported (get, put, post, etc.).
 
 Each request method mock have to be declared in the config file. Otherwise, the `callback` method is used.
+
+## Logging
+
+You can monitor each call, that has been intercepted by superagent-mock or not, by passing a callback function at initialization.
+
+``` js
+// ./server.js file
+var request = require('superagent');
+var config = require('./superagent-mock-config');
+
+var logger = function(log)  {
+  console.log('superagent call', log);
+};
+
+// Before tests
+var superagentMock = require('superagent-mock')(request, config, logger);
+
+...
+
+// After tests
+superagentMock.unset();
+```
+
+The callback function will be called with an object containing the following informations
+ - data : data used with `superagent.send` function
+ - headers : array of headers given by `superagent.set` function
+ - matcher : regex matching the current url which is defined in the provided config
+ - url : url which superagent was called
+ - method : HTTP method used for the call
+ - timestamp : timestamp of the superagent call
+ - mocked : true if the call was mocked by superagent mock, false if it used superagent real methods
 
 ## Tests
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -9,11 +9,16 @@ module.exports = mock;
 
 /**
  * Installs the `mock` extension to superagent.
+ * @param superagent Superagent instance
+ * @param config The mock configuration
+ * @param logger Logger callback
  */
-function mock (superagent, config) {
+function mock (superagent, config, logger) {
   var Request = superagent.Request;
   var parsers = Object.create(null);
   var response = {};
+  var currentLog = {};
+  var logEnabled = !!logger;
 
   /**
    * Keep the default methods
@@ -22,6 +27,15 @@ function mock (superagent, config) {
   var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
   var oldAbort = Request.prototype.abort;
+
+  /**
+   * Flush the current log in the logger method and reset it
+   */
+  function flushLog() {
+    logger(currentLog);
+
+    currentLog = {};
+  }
 
   /**
    * Attempt to match url against the patterns in fixtures.
@@ -44,6 +58,9 @@ function mock (superagent, config) {
    * Override send function
    */
   Request.prototype.send = function (data) {
+    if (logEnabled) {
+      currentLog.data = data;
+    }
 
     var parser = testUrlForPatterns(this.url);
     if (parser) {
@@ -67,6 +84,12 @@ function mock (superagent, config) {
    * Override set function
    */
   Request.prototype.set = function (field, val) {
+    if (logEnabled && !isObject(field)) {
+      var headerPart = {};
+      headerPart[field] = val;
+      currentLog.headers = (currentLog.headers || []).concat(headerPart);
+    }
+
     var parser = testUrlForPatterns(this.url);
     if (parser) {
       if (isObject(field)) {
@@ -77,6 +100,7 @@ function mock (superagent, config) {
         this.headers = this.headers || {};
         this.headers[field] = val;
       }
+
       return this;
     } else {
       return oldSet.apply(this, arguments);
@@ -108,6 +132,15 @@ function mock (superagent, config) {
     }
 
     var parser = testUrlForPatterns(this.url);
+
+    if (logEnabled) {
+      currentLog.matcher = parser && parser.pattern;
+      currentLog.mocked = !!parser;
+      currentLog.url = this.url;
+      currentLog.method = this.method;
+      currentLog.timestamp = new Date().getTime();
+      flushLog();
+    }
 
     if (parser) {
       var match = new RegExp(parser.pattern, 'g').exec(path);


### PR DESCRIPTION
From #30 

Use a callback to log any call made with superagent, mocked or not.
The callback will be called with an object containing information like headers, called url, matching regexp, HTTP method and call timestamp.