### PR TITLE
superagent 2.x deprecates setStatusProperties

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -171,7 +171,11 @@ function mock (superagent, config, logger) {
             getResponseHeader: function () {return err.responseHeader || 'a header';}
           }
         });
-        response.setStatusProperties(err.message);
+        if (response._setStatusProperties) {
+          response._setStatusProperties(err.message);
+        } else {
+          response.setStatusProperties(err.message);
+        }
       }
 
       fn(error, response);


### PR DESCRIPTION
Using response._setStatusProperties if available to avoid warning about superagent.2.x making setStatusProperties method private