### PR TITLE
Fix running tests for npm 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - '0.10'
+  - '6'
 script: npm run lint && npm test

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -6,11 +6,21 @@ var component = require('component-as-module');
 // Get the "client" version of superagent
 var request = component('tests/support', function (loader) {
   loader.register('component-emitter', function () {
-    return require('superagent/node_modules/component-emitter');
+    try {
+      // npm >= 3
+      return require('component-emitter');
+    } catch (e) {
+      return require('superagent/node_modules/component-emitter');
+    }
   });
 
   loader.register('component-reduce', function () {
-    return require('superagent/node_modules/reduce-component');
+    try {
+      // npm >= 3
+      return require('reduce-component');
+    } catch (e) {
+      return require('superagent/node_modules/reduce-component');
+    }
   });
 
   loader.loadDependency('emitter');


### PR DESCRIPTION
This fix ensures running `npm test` with a node_modules generated by npm 2 or 3.
