### PR TITLE
Strict match parametrized request

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -101,14 +101,27 @@ function mock (superagent, config, logger) {
       path += (~path.indexOf('?') ? '&' : '?') + querystring;
     }
 
-    // Attempt to match url against the patterns in fixtures.
+    // Attempt to match path against the patterns in fixtures
     var parser = null;
     for (var i = 0, len = config.length; i < len; i++) {
       if (new RegExp(config[i].pattern, 'g').test(path)){
         if (!parser) {
           parser = config[i];
         } else if (logEnabled) {
-          currentLog.warning = 'An other pattern matches this request';
+          currentLog.warnings = (currentLog.warnings || []).concat([
+            'This other pattern matches the query but was ignored: ' + config[i].pattern
+          ]);
+        }
+      }
+    }
+
+    // For warning purpose: attempt to match url against the patterns in fixtures
+    if (!parser && logEnabled) {
+      for (i = 0, len = config.length; i < len; i++) {
+        if (new RegExp(config[i].pattern, 'g').test(this.url)){
+          currentLog.warnings = (currentLog.warnings || []).concat([
+            'This pattern was ignored because it doesn\'t matches the query params: ' + config[i].pattern
+          ]);
         }
       }
     }
@@ -125,6 +138,7 @@ function mock (superagent, config, logger) {
     if (!parser) {
       oldSet.call(this, this.headers);
       oldSend.call(this, this.params);
+
       return oldEnd.call(this, fn);
     }
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -39,16 +39,16 @@ function mock (superagent, config, logger) {
   /**
    * Loop over the patterns and use @callback when the @query matches
    */
-  var forEachPatternMatch = function() {
+  var forEachPatternMatch = function () {
     var configLength = config.length;
 
-    return function(query, callback){
+    return function (query, callback){
       for (var i = 0; i < configLength; i++) {
         if (new RegExp(config[i].pattern, 'g').test(query)){
           callback(config[i]);
         }
       }
-    }
+    };
   }();
 
   /**
@@ -118,21 +118,21 @@ function mock (superagent, config, logger) {
 
     // Attempt to match path against the patterns in fixtures
     var parser = null;
-    forEachPatternMatch(path, function(configBlock) {
+    forEachPatternMatch(path, function (matched) {
       if (!parser) {
-        parser = configBlock;
+        parser = matched;
       } else if (logEnabled) {
         currentLog.warnings = (currentLog.warnings || []).concat([
-          'This other pattern matches the query but was ignored: ' + configBlock.pattern
+          'This other pattern matches the query but was ignored: ' + matched.pattern
         ]);
       }
     });
 
     // For warning purpose: attempt to match url against the patterns in fixtures
     if (!parser && logEnabled) {
-      forEachPatternMatch(this.url, function(configBlock) {
+      forEachPatternMatch(this.url, function (matched) {
         currentLog.warnings = (currentLog.warnings || []).concat([
-          'This pattern was ignored because it doesn\'t matches the query params: ' + configBlock.pattern
+          'This pattern was ignored because it doesn\'t matches the query params: ' + matched.pattern
         ]);
       });
     }

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -118,7 +118,7 @@ function mock (superagent, config, logger) {
 
     // Attempt to match path against the patterns in fixtures
     var parser = null;
-    forEachPatternMatch(path, function(configBlock){
+    forEachPatternMatch(path, function(configBlock) {
       if (!parser) {
         parser = configBlock;
       } else if (logEnabled) {
@@ -130,7 +130,7 @@ function mock (superagent, config, logger) {
 
     // For warning purpose: attempt to match url against the patterns in fixtures
     if (!parser && logEnabled) {
-      forEachPatternMatch(this.url, function(configBlock){
+      forEachPatternMatch(this.url, function(configBlock) {
         currentLog.warnings = (currentLog.warnings || []).concat([
           'This pattern was ignored because it doesn\'t matches the query params: ' + configBlock.pattern
         ]);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -37,6 +37,21 @@ function mock (superagent, config, logger) {
   }
 
   /**
+   * Loop over the patterns and use @callback when the @query matches
+   */
+  var forEachPatternMatch = function() {
+    var configLength = config.length;
+
+    return function(query, callback){
+      for (var i = 0; i < configLength; i++) {
+        if (new RegExp(config[i].pattern, 'g').test(query)){
+          callback(config[i]);
+        }
+      }
+    }
+  }();
+
+  /**
    * Override send function
    */
   Request.prototype.send = function (data) {
@@ -103,27 +118,23 @@ function mock (superagent, config, logger) {
 
     // Attempt to match path against the patterns in fixtures
     var parser = null;
-    for (var i = 0, len = config.length; i < len; i++) {
-      if (new RegExp(config[i].pattern, 'g').test(path)){
-        if (!parser) {
-          parser = config[i];
-        } else if (logEnabled) {
-          currentLog.warnings = (currentLog.warnings || []).concat([
-            'This other pattern matches the query but was ignored: ' + config[i].pattern
-          ]);
-        }
+    forEachPatternMatch(path, function(configBlock){
+      if (!parser) {
+        parser = configBlock;
+      } else if (logEnabled) {
+        currentLog.warnings = (currentLog.warnings || []).concat([
+          'This other pattern matches the query but was ignored: ' + configBlock.pattern
+        ]);
       }
-    }
+    });
 
     // For warning purpose: attempt to match url against the patterns in fixtures
     if (!parser && logEnabled) {
-      for (i = 0, len = config.length; i < len; i++) {
-        if (new RegExp(config[i].pattern, 'g').test(this.url)){
-          currentLog.warnings = (currentLog.warnings || []).concat([
-            'This pattern was ignored because it doesn\'t matches the query params: ' + config[i].pattern
-          ]);
-        }
-      }
+      forEachPatternMatch(this.url, function(configBlock){
+        currentLog.warnings = (currentLog.warnings || []).concat([
+          'This pattern was ignored because it doesn\'t matches the query params: ' + configBlock.pattern
+        ]);
+      });
     }
 
     if (logEnabled) {

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -15,7 +15,6 @@ module.exports = mock;
  */
 function mock (superagent, config, logger) {
   var Request = superagent.Request;
-  var parsers = Object.create(null);
   var response = {};
   var currentLog = {};
   var logEnabled = !!logger;
@@ -38,23 +37,6 @@ function mock (superagent, config, logger) {
   }
 
   /**
-   * Attempt to match url against the patterns in fixtures.
-   */
-  function testUrlForPatterns(url) {
-    if (parsers[url]) {
-      return parsers[url];
-    }
-
-    var match = config.filter(function (parser) {
-      return new RegExp(parser.pattern, 'g').test(url);
-    })[0] || null;
-
-    parsers[url] = match;
-
-    return match;
-  }
-
-  /**
    * Override send function
    */
   Request.prototype.send = function (data) {
@@ -62,14 +44,9 @@ function mock (superagent, config, logger) {
       currentLog.data = data;
     }
 
-    var parser = testUrlForPatterns(this.url);
-    if (parser) {
-      this.params = data;
+    this.params = data;
 
-      return this;
-    }
-
-    return oldSend.call(this, data);
+    return this;
   };
 
   /**
@@ -87,11 +64,6 @@ function mock (superagent, config, logger) {
       var headerPart = {};
       headerPart[field] = val;
       currentLog.headers = (currentLog.headers || []).concat(headerPart);
-    }
-
-    var parser = testUrlForPatterns(this.url);
-    if (!parser) {
-      return oldSet.apply(this, arguments);
     }
 
     if (isObject(field)) {
@@ -125,23 +97,34 @@ function mock (superagent, config, logger) {
       }
     }
 
-
     if (querystring.length) {
       path += (~path.indexOf('?') ? '&' : '?') + querystring;
     }
 
-    var parser = testUrlForPatterns(this.url);
+    // Attempt to match url against the patterns in fixtures.
+    var parser = null;
+    for (var i = 0, len = config.length; i < len; i++) {
+      if (new RegExp(config[i].pattern, 'g').test(path)){
+        if (!parser) {
+          parser = config[i];
+        } else if (logEnabled) {
+          currentLog.warning = 'An other pattern matches this request';
+        }
+      }
+    }
 
     if (logEnabled) {
       currentLog.matcher = parser && parser.pattern;
       currentLog.mocked = !!parser;
-      currentLog.url = this.url;
+      currentLog.url = path;
       currentLog.method = this.method;
       currentLog.timestamp = new Date().getTime();
       flushLog();
     }
 
     if (!parser) {
+      oldSet.call(this, this.headers);
+      oldSend.call(this, this.params);
       return oldEnd.call(this, fn);
     }
 
@@ -150,7 +133,7 @@ function mock (superagent, config, logger) {
     try {
       var fixtures = parser.fixtures(match, this.params, this.headers);
       var method = this.method.toLocaleLowerCase();
-      var parserMethod = parsers[this.url][method] ? parsers[this.url][method] : parsers[this.url].callback;
+      var parserMethod = parser[method] || parser.callback;
 
       response = parserMethod(match, fixtures);
     } catch(err) {
@@ -188,7 +171,7 @@ function mock (superagent, config, logger) {
     this.xhr = {abort: function () {}};
     this.req = {abort: function () {}};
 
-    oldAbort.bind(this)();
+    return oldAbort.call(this);
   };
 
   return {

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -34,10 +34,37 @@ module.exports = [
     }
   },
   {
+    pattern: 'https://domain.strict-params.example/search\\?(q=\\w+)&(page=\\d+)',
+    fixtures: function () {
+      return 'Fixture !';
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
     pattern: 'https://match.example/(\\w+)',
     fixtures: function (match) {
       return match && match[1];
     },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
+    pattern: 'https://match.example/foo',
     get: function (match, data) {
       return {match: match, data: data};
     },

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -49,6 +49,21 @@ module.exports = [
     }
   },
   {
+    pattern: 'https://forget.query.params$',
+    fixtures: function () {
+      return 'Fixture !';
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
     pattern: 'https://match.example/(\\w+)',
     fixtures: function (match) {
       return match && match[1];

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -190,7 +190,19 @@ module.exports = function (request, config) {
         request.get(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
-            test.equal(currentLog.warning, 'An other pattern matches this request');
+            test.deepEqual(currentLog.warnings, ['This other pattern matches the query but was ignored: https://match.example/foo']);
+            test.done();
+          });
+      },
+
+      'attempt to match without query params': function (test) {
+        var url = 'https://forget.query.params';
+        request.get(url)
+          .query({param: 'forget'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.deepEqual(currentLog.warnings, ['This pattern was ignored because it doesn\'t matches the query params: https://forget.query.params$']);
             test.done();
           });
       },
@@ -385,7 +397,19 @@ module.exports = function (request, config) {
         request.post(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
-            test.equal(currentLog.warning, 'An other pattern matches this request');
+            test.deepEqual(currentLog.warnings, ['This other pattern matches the query but was ignored: https://match.example/foo']);
+            test.done();
+          });
+      },
+
+      'attempt to match without query params': function (test) {
+        var url = 'https://forget.query.params';
+        request.post(url)
+          .query({param: 'forget'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.deepEqual(currentLog.warnings, ['This pattern was ignored because it doesn\'t matches the query params: https://forget.query.params$']);
             test.done();
           });
       },
@@ -590,7 +614,19 @@ module.exports = function (request, config) {
         request.put(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
-            test.equal(currentLog.warning, 'An other pattern matches this request');
+            test.deepEqual(currentLog.warnings, ['This other pattern matches the query but was ignored: https://match.example/foo']);
+            test.done();
+          });
+      },
+
+      'attempt to match without query params': function (test) {
+        var url = 'https://forget.query.params';
+        request.put(url)
+          .query({param: 'forget'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.deepEqual(currentLog.warnings, ['This pattern was ignored because it doesn\'t matches the query params: https://forget.query.params$']);
             test.done();
           });
       },
@@ -628,7 +664,6 @@ module.exports = function (request, config) {
         request.put('https://authorized.example/')
           .set({Authorization: "valid_token"})
           .end(function (err, result) {
-            console.log(err);
             test.ok(!err);
             test.equal(result.data, 'your token: valid_token');
             test.equal(headers, null);

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -123,6 +123,49 @@ module.exports = function (request, config) {
           });
       },
 
+      'matching strict parametrized request (with url)': function (test) {
+        request.get('https://domain.strict-params.example/search?q=word&page=1')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'matching strict parametrized request (mixed)': function (test) {
+        request.get('https://domain.strict-params.example/search?q=word')
+          .query({page: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (missing parameter)': function (test) {
+        request.get('https://domain.strict-params.example/search')
+          .query({q: 'word'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (wrong parameter)': function (test) {
+        request.get('https://domain.strict-params.example/search?q=word')
+          .query({q: 'word', limit: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
       'matching parametrized request (no parameters)': function (test) {
         request.get('https://domain.params.example/list')
           .end(function (err, result) {
@@ -147,6 +190,7 @@ module.exports = function (request, config) {
         request.get(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
+            test.equal(currentLog.warning, 'An other pattern matches this request');
             test.done();
           });
       },
@@ -274,6 +318,49 @@ module.exports = function (request, config) {
           });
       },
 
+      'matching strict parametrized request (with url)': function (test) {
+        request.post('https://domain.strict-params.example/search?q=word&page=1')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'matching strict parametrized request (mixed)': function (test) {
+        request.post('https://domain.strict-params.example/search?q=word')
+          .query({page: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (missing parameter)': function (test) {
+        request.post('https://domain.strict-params.example/search')
+          .query({q: 'word'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (wrong parameter)': function (test) {
+        request.post('https://domain.strict-params.example/search?q=word')
+          .query({q: 'word', limit: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
       'matching parametrized request (no parameters)': function (test) {
         request.post('https://domain.params.example/list')
           .end(function (err, result) {
@@ -298,6 +385,7 @@ module.exports = function (request, config) {
         request.post(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
+            test.equal(currentLog.warning, 'An other pattern matches this request');
             test.done();
           });
       },
@@ -435,6 +523,49 @@ module.exports = function (request, config) {
           });
       },
 
+      'matching strict parametrized request (with url)': function (test) {
+        request.put('https://domain.strict-params.example/search?q=word&page=1')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'matching strict parametrized request (mixed)': function (test) {
+        request.put('https://domain.strict-params.example/search?q=word')
+          .query({page: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
+            test.equal(result.data, 'Fixture !');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (missing parameter)': function (test) {
+        request.put('https://domain.strict-params.example/search')
+          .query({q: 'word'})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
+      'unmatching strict parametrized request (wrong parameter)': function (test) {
+        request.put('https://domain.strict-params.example/search?q=word')
+          .query({q: 'word', limit: 1})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
+      },
+
       'matching parametrized request (no parameters)': function (test) {
         request.put('https://domain.params.example/list')
           .end(function (err, result) {
@@ -459,6 +590,7 @@ module.exports = function (request, config) {
         request.put(url)
           .end(function (err, result) {
             test.equal(result.data, 'foo');
+            test.equal(currentLog.warning, 'An other pattern matches this request');
             test.done();
           });
       },
@@ -496,6 +628,7 @@ module.exports = function (request, config) {
         request.put('https://authorized.example/')
           .set({Authorization: "valid_token"})
           .end(function (err, result) {
+            console.log(err);
             test.ok(!err);
             test.equal(result.data, 'your token: valid_token');
             test.equal(headers, null);


### PR DESCRIPTION
At the moment, we match only the url against the patterns **without its query params**. It appears to be a problem once we need mandatory parameters in the query or if we don't want at all any parameters.

Current match unexpected:

```
query: request.get('https://search.domain').query({q: 'test'})
pattern: 'https://search.domain$'
```

Should match:

```
query: request.get('https://search.domain').query({q: 'test'})
pattern: 'https://search.domain\\?q=test'
```

Should produce the same result (superagent is able to mix uri and query params):

```
query: request.get('https://search.domain').query({q: 'test'})
query 2: request.get('https://search.domain?q=test')
pattern: 'https://search.domain$'
```

This PR also comes with a warning log when multiple patterns match a query.

:warning: Allowing the strict match could eventually break some current mocks. It has to be merged on a major release with a breaking change notice.
