### PR TITLE
Install superagent before testing for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - '0.10'
   - '6'
-script: npm run lint && npm test
+script: npm install superagent@2.* && npm run lint && npm test


### PR DESCRIPTION
Because peerDependencies is no more installed with npm3.