### PR TITLE
fix(request): Fixed request end method .toLowerCase() error

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -147,7 +147,7 @@ function mock (superagent, config, logger) {
     }
 
     if (!parser) {
-      oldSet.call(this, this.headers);
+      oldSet.call(this, this.headers || {});
       oldSend.call(this, this.params);
 
       return oldEnd.call(this, fn);

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -19,7 +19,7 @@ module.exports = function (request, config) {
         fn(null, 'Real call done');
       };
 
-      const oldSet = request.Request.prototype.set;
+      var oldSet = request.Request.prototype.set;
       request.Request.prototype.set = function (values) {
         headers = values;
 

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -19,10 +19,11 @@ module.exports = function (request, config) {
         fn(null, 'Real call done');
       };
 
+      const oldSet = request.Request.prototype.set;
       request.Request.prototype.set = function (values) {
         headers = values;
 
-        return this;
+        return oldSet.call(this, values);
       };
 
       // Init module


### PR DESCRIPTION
## Bug

When request is real (request is using original superagent methods) and having no headers set, the `Request.prototype.end()` method was broken. The original `Request.prototype.set` method was mocked and prevented the tests from failing and detecting this case.

## Solution

The tests were updated, we no longer mock the original `set` method. An empty object is provided to the `set` method in case `request.headers` is undefined.