### PR TITLE
Hook only on 'end' and 'abort'

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var qs = require('qs');
-
 /**
  * Module exports.
  */
@@ -22,8 +20,6 @@ function mock (superagent, config, logger) {
   /**
    * Keep the default methods
    */
-  var oldSet = Request.prototype.set;
-  var oldSend = Request.prototype.send;
   var oldEnd = Request.prototype.end;
   var oldAbort = Request.prototype.abort;
 
@@ -52,68 +48,24 @@ function mock (superagent, config, logger) {
   }();
 
   /**
-   * Override send function
-   */
-  Request.prototype.send = function (data) {
-    if (logEnabled) {
-      currentLog.data = data;
-    }
-
-    this.params = data;
-
-    return this;
-  };
-
-  /**
-   * Returns true if `obj` is an object.
-   */
-  function isObject(obj) {
-    return obj === Object(obj);
-  }
-
-  /**
-   * Override set function
-   */
-  Request.prototype.set = function (field, val) {
-    if (logEnabled && !isObject(field)) {
-      var headerPart = {};
-      headerPart[field] = val;
-      currentLog.headers = (currentLog.headers || []).concat(headerPart);
-    }
-
-    if (isObject(field)) {
-        for (var key in field) {
-          this.set(key, field[key]);
-        }
-    } else {
-        this.headers = this.headers || {};
-        this.headers[field] = val;
-    }
-
-    return this;
-  };
-
-  /**
    * Override end function
    */
   Request.prototype.end = function (fn) {
-    var path = this.url;
-    var querystring = '';
+    var originalUrl = this.url;
     var error = null;
+    var path;
+    var isNodeServer = this.hasOwnProperty('cookies');
 
-    if (this._query) {
-      querystring += this._query.join('&');
-    } else {
-      if (this.qs) {
-        querystring += qs.stringify(this.qs);
-      }
-      if (this.qsRaw) {
-        querystring += this.qsRaw.join('&');
-      }
+    if (isNodeServer) { // node server
+      this.path = this.url;
+      this._appendQueryString(this); // use superagent implementation of adding the query
+      path = this.path; // save the url together with the query
+      this.url = originalUrl; // reverse the addition of query to url by _appendQueryString
     }
-
-    if (querystring.length) {
-      path += (~path.indexOf('?') ? '&' : '?') + querystring;
+    else { // client
+      this._appendQueryString(this); // use superagent implementation of adding the query
+      path = this.url; // save the url together with the query
+      this.url = originalUrl; // reverse the addition of query to url by _appendQueryString
     }
 
     // Attempt to match path against the patterns in fixtures
@@ -142,21 +94,20 @@ function mock (superagent, config, logger) {
       currentLog.mocked = !!parser;
       currentLog.url = path;
       currentLog.method = this.method;
+      currentLog.data = this._data;
+      currentLog.headers = this.header;
       currentLog.timestamp = new Date().getTime();
       flushLog();
     }
 
     if (!parser) {
-      oldSet.call(this, this.headers || {});
-      oldSend.call(this, this.params);
-
       return oldEnd.call(this, fn);
     }
 
     var match = new RegExp(parser.pattern, 'g').exec(path);
 
     try {
-      var fixtures = parser.fixtures(match, this.params, this.headers);
+      var fixtures = parser.fixtures(match, this._data, this.header);
       var method = this.method.toLocaleLowerCase();
       var parserMethod = parser[method] || parser.callback;
 
@@ -193,16 +144,13 @@ function mock (superagent, config, logger) {
   };
 
   Request.prototype.abort = function () {
-    this.xhr = {abort: function () {}};
-    this.req = {abort: function () {}};
+    this.xhr = this.req = {abort: function () {}};
 
     return oldAbort.call(this);
   };
 
   return {
     unset: function () {
-      Request.prototype.send = oldSend;
-      Request.prototype.set = oldSet;
       Request.prototype.end = oldEnd;
       Request.prototype.abort = oldAbort;
     }

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -51,18 +51,19 @@ function mock (superagent, config, logger) {
    * Override end function
    */
   Request.prototype.end = function (fn) {
-    var originalUrl = this.url;
     var error = null;
     var path;
     var isNodeServer = this.hasOwnProperty('cookies');
 
     if (isNodeServer) { // node server
+      var originalPath = this.path;
       this.path = this.url;
       this._appendQueryString(this); // use superagent implementation of adding the query
       path = this.path; // save the url together with the query
-      this.url = originalUrl; // reverse the addition of query to url by _appendQueryString
+      this.path = originalPath; // reverse the addition of query to path by _appendQueryString
     }
     else { // client
+      var originalUrl = this.url;
       this._appendQueryString(this); // use superagent implementation of adding the query
       path = this.url; // save the url together with the query
       this.url = originalUrl; // reverse the addition of query to url by _appendQueryString

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -61,8 +61,7 @@ function mock (superagent, config, logger) {
       this._appendQueryString(this); // use superagent implementation of adding the query
       path = this.path; // save the url together with the query
       this.path = originalPath; // reverse the addition of query to path by _appendQueryString
-    }
-    else { // client
+    } else { // client
       var originalUrl = this.url;
       this._appendQueryString(this); // use superagent implementation of adding the query
       path = this.url; // save the url together with the query

--- a/package.json
+++ b/package.json
@@ -17,16 +17,13 @@
   "peerDependencies": {
     "superagent": "^3.2.0"
   },
-  "dependencies": {
-    "qs": "^2.3.3"
-  },
   "devDependencies": {
     "component-as-module": "0.3.0",
     "eslint": "0.12.0",
     "nodeunit": "0.9.0"
   },
   "scripts": {
-    "test": "./node_modules/nodeunit/bin/nodeunit ./tests",
-    "lint": "./node_modules/eslint/bin/eslint.js ./lib"
+    "test": "nodeunit ./tests",
+    "lint": "eslint ./lib"
   }
 }

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -33,4 +33,4 @@ var config = require('./support/config');
 var expectations = require('./support/expectations');
 
 // Expose the test cases
-module.exports = expectations(request, config);
+module.exports = expectations(request, config, false);

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -8,4 +8,4 @@ var config = require('./support/config');
 var expectations = require('./support/expectations');
 
 // Expose the test cases
-module.exports = expectations(request, config);
+module.exports = expectations(request, config, true);

--- a/tests/support/component.json
+++ b/tests/support/component.json
@@ -8,7 +8,7 @@
     "../../node_modules/superagent/lib/response-base.js",
     "../../node_modules/superagent/lib/utils.js"
   ],
-  "main": "../../node_modules/superagent/lib/client.js",
+  "main": "..\\..\\node_modules\\superagent\\lib\\client.js",
   "dependencies": {
     "component/emitter": "*",
     "component/reduce": "*"

--- a/tests/support/component.json
+++ b/tests/support/component.json
@@ -8,7 +8,7 @@
     "../../node_modules/superagent/lib/response-base.js",
     "../../node_modules/superagent/lib/utils.js"
   ],
-  "main": "..\\..\\node_modules\\superagent\\lib\\client.js",
+  "main": "../../node_modules/superagent/lib/client.js",
   "dependencies": {
     "component/emitter": "*",
     "component/reduce": "*"

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -567,8 +567,8 @@ module.exports = function (request, config, isServer) {
           .query({page: 1})
           .end(function (err, result) {
             test.ok(!err);
-            test.notEqual(result.match[0].indexOf('q=word'), -1);
-            test.notEqual(result.match[0].indexOf('page=1'), -1);
+            test.notEqual(result.match.indexOf('q=word'), -1);
+            test.notEqual(result.match.indexOf('page=1'), -1);
             test.equal(result.data, 'Fixture !');
             test.done();
           });

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var superagentPackage = require('superagent/package.json');
-var superagentUserAgent = 'node-superagent/' + superagentPackage.version;
-
 var http = require('http');
 
 module.exports = function (request, config, isServer) {
@@ -12,6 +9,8 @@ module.exports = function (request, config, isServer) {
   var logger = function (log) {
     currentLog = log;
   };
+  var superagentPackage = require('superagent/package.json');
+  var superagentUserAgentHeader = isServer ? {"User-Agent": 'node-superagent/' + superagentPackage.version} : {};
 
   return {
 
@@ -26,6 +25,7 @@ module.exports = function (request, config, isServer) {
         if (typeof field === 'object') { // spy on set to collect the used arguments
           headers = field;
         }
+
         return oldSet.call(this, field, value);
       };
 
@@ -412,7 +412,7 @@ module.exports = function (request, config, isServer) {
           .query({param: 'forget'})
           .end(function (err, result) {
             test.ok(!err);
-            test.equal(result.match.length, 1); //no other match
+            test.equal(result, 'Real call done');
             test.deepEqual(currentLog.warnings, ['This pattern was ignored because it doesn\'t matches the query params: https://forget.query.params$']);
             test.done();
           });
@@ -683,10 +683,7 @@ module.exports = function (request, config, isServer) {
                                    .end(function(err, result){});
 
         test.equal(requestObject.url, 'https://domain.example/test');
-        test.deepEqual(requestObject.header, isServer
-            ? { "User-Agent": superagentUserAgent, header: 'value' }
-            : { header: 'value' }
-          );
+        test.deepEqual(requestObject.header, Object.assign({header: 'value'}, superagentUserAgentHeader));
         test.done();
       },
       'is only called once': function(test) {
@@ -711,9 +708,7 @@ module.exports = function (request, config, isServer) {
           test.equal(currentLog.mocked, true);
           test.equal(currentLog.url, 'https://domain.example/666');
           test.equal(currentLog.method, 'GET');
-          test.deepEqual(currentLog.headers, isServer
-            ? {"User-Agent": superagentUserAgent}
-            : {});
+          test.deepEqual(currentLog.headers, superagentUserAgentHeader);
           test.done();
         });
       },
@@ -725,8 +720,7 @@ module.exports = function (request, config, isServer) {
           test.equal(currentLog.mocked, true);
           test.equal(currentLog.url, 'https://domain.example/666');
           test.equal(currentLog.method, 'PUT');
-          test.deepEqual(currentLog.headers, isServer
-            ? {"User-Agent": superagentUserAgent}:{});
+          test.deepEqual(currentLog.headers, superagentUserAgentHeader);
           test.done();
         });
       },
@@ -738,9 +732,7 @@ module.exports = function (request, config, isServer) {
           test.equal(currentLog.mocked, true);
           test.equal(currentLog.url, 'https://domain.example/666');
           test.equal(currentLog.method, 'POST');
-          test.deepEqual(currentLog.headers, isServer
-            ? {"User-Agent": superagentUserAgent, 'Content-Type': 'application/x-www-form-urlencoded'}
-            : {'Content-Type': 'application/x-www-form-urlencoded'});
+          test.deepEqual(currentLog.headers, Object.assign({'Content-Type': 'application/x-www-form-urlencoded'}, superagentUserAgentHeader));
           test.done();
         });
       },
@@ -754,9 +746,7 @@ module.exports = function (request, config, isServer) {
             test.equal(currentLog.mocked, true);
             test.equal(currentLog.url, 'https://authorized.example/');
             test.equal(currentLog.method, 'PUT');
-            test.deepEqual(currentLog.headers, isServer
-              ? {"User-Agent": superagentUserAgent, Authorization: 'valid_token', "x-6play": 1}
-              : { Authorization: 'valid_token', "x-6play": 1});
+            test.deepEqual(currentLog.headers, Object.assign({Authorization: 'valid_token', "x-6play": 1}, superagentUserAgentHeader));
             test.done();
           });
       },
@@ -771,9 +761,7 @@ module.exports = function (request, config, isServer) {
             test.equal(currentLog.mocked, true);
             test.equal(currentLog.url, 'https://authorized.example/');
             test.equal(currentLog.method, 'PUT');
-            test.deepEqual(currentLog.headers, isServer
-              ? {"User-Agent": superagentUserAgent, Authorization: 'valid_token', "x-6play": 1}
-              : {Authorization: 'valid_token', "x-6play": 1});
+            test.deepEqual(currentLog.headers, Object.assign({Authorization: 'valid_token', "x-6play": 1}, superagentUserAgentHeader));
             test.done();
           });
       }

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -664,6 +664,15 @@ module.exports = function (request, config, isServer) {
       }
     },
     'Header setting': {
+      'setting mocked headers': function (test) {
+        request.put('https://authorized.example/')
+          .set({Authorization: "valid_token"})
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result.data, 'your token: valid_token');
+            test.done();
+          });
+      },
 
       'setting real headers': function (test) {
         request.put('https://dummy.example/')


### PR DESCRIPTION
fix implementation to only hook on end and abort to better support the latest version and future versions (all unit tests were updated)

This fixes #46 