### PR TITLE
Add support for cancelling mocking after pattern match

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ module.exports = [
      * @param match array Result of the resolution of the regular expression
      * @param params object sent by 'send' function
      * @param headers object set by 'set' function
+     * @param context object the context of running the fixtures function
      */
-    fixtures: function (match, params, headers) {
+    fixtures: function (match, params, headers, context) {
       /**
        * Returning error codes example:
        *   request.get('https://domain.example/404').end(function(err, res){
@@ -92,6 +93,18 @@ module.exports = [
         } else {
           throw new Error(401); // Unauthorized
         }
+      }
+
+      /**
+       * Cancelling the mocking for a specific matched route example:
+       *   request.get('https://domain.example/server_test').end(function(err, res){
+       *     console.log(res.body); // (whatever the actual server would have returned)
+       *   })
+       */
+
+      if (match[1] === '/server_test') {
+        context.cancel = true; // This will cancel the mock process and continue as usual (unmocked)
+        return null;
       }
 
     },

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -107,10 +107,13 @@ function mock (superagent, config, logger) {
     var match = new RegExp(parser.pattern, 'g').exec(path);
 
     try {
-      var fixtures = parser.fixtures(match, this._data, this.header);
+      var context = {};
+      var fixtures = parser.fixtures(match, this._data, this.header, context);
+      if (context.cancel === true) {
+        return oldEnd.call(this, fn); // mocking was cancelled from within fixtures
+      }
       var method = this.method.toLocaleLowerCase();
       var parserMethod = parser[method] || parser.callback;
-
       response = parserMethod(match, fixtures);
     } catch(err) {
         error = err;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "devDependencies": {
     "component-as-module": "0.3.0",
     "eslint": "0.12.0",
-    "nodeunit": "0.10.2"
+    "nodeunit": "0.10.2",
+    "superagent": "^3.3.1"
   },
   "scripts": {
     "test": "nodeunit ./tests",

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -179,5 +179,23 @@ module.exports = [
     callback: function (match, data) {
       return {match: match, data: data};
     }
+  },
+  {
+    pattern: 'https://match.toomuch.example/([\\w-]+)',
+    fixtures: function (match, data, headers, context) {
+      if (match && match[1] === 'real-call') {
+        context.cancel = true;
+      }
+      return match && match[1];
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
   }
 ];

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -706,6 +706,22 @@ module.exports = function (request, config, isServer) {
         }, Error, 'Should throw internal exception');
         test.equal(calls, 1);
         test.done();
+      },
+      'not calling real api if not cancelled': function (test) {
+        request.put('https://match.toomuch.example/mock-call')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.notEqual(result, 'Real call done');
+            test.done();
+          });
+      },
+      'calling real api when cancelled': function (test) {
+        request.put('https://match.toomuch.example/real-call')
+          .end(function (err, result) {
+            test.ok(!err);
+            test.equal(result, 'Real call done');
+            test.done();
+          });
       }
     },
     'Logger': {


### PR DESCRIPTION
This adds support for cancelling mocking after pattern match through fixtures function.

the following test can demonstrate the use case:
```js
{
    pattern: 'https://match.toomuch.example/([\\w-]+)',
    fixtures: function (match, data, headers, context) {
      if (match && match[1] === 'real-call') {
        context.cancel = true;
      }
      return match && match[1];
    },
    get: function (match, data) {
      return {match: match, data: data};
    },
    post: function (match, data) {
      return {match: match, data: data};
    },
    put: function (match, data) {
      return {match: match, data: data};
    }
  }
```

2 Unit tests added.