### PR TITLE
Support delay option

### DIFF
--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -142,7 +142,7 @@ function mock (superagent, config, logger) {
       }
     }
 
-    setTimeout(function () { fn(error, response) }, context.delay || 0);
+    setTimeout(function () { fn(error, response); }, context.delay || 0);
     return this;
   };
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -142,7 +142,7 @@ function mock (superagent, config, logger) {
       }
     }
 
-    fn(error, response);
+    setTimeout(function () { fn(error, response) }, context.delay || 0);
     return this;
   };
 

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -13,7 +13,6 @@ module.exports = mock;
  */
 function mock (superagent, config, logger) {
   var Request = superagent.Request;
-  var response = {};
   var currentLog = {};
   var logEnabled = !!logger;
 
@@ -114,7 +113,7 @@ function mock (superagent, config, logger) {
       }
       var method = this.method.toLocaleLowerCase();
       var parserMethod = parser[method] || parser.callback;
-      response = parserMethod(match, fixtures);
+      var response = parserMethod(match, fixtures);
     } catch(err) {
         error = err;
         response = new superagent.Response({


### PR DESCRIPTION
The goal is to be able to delay the request. Sometimes requests take long time and it would be great to set the same latency in the mock to see how the application handles this latency.