### PR TITLE
Add support for asynchronously delaying mocked responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ module.exports = [
       /**
        * Delaying the response with a specific number of milliseconds:
        *   request.get('https://domain.example/delay_test').end(function(err, res){
-       *     console.log(res.body); // This log will be written after the delay time have passed 
+       *     console.log(res.body); // This log will be written after the delay time has passed 
        *   })
        */
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module.exports = [
         if(params['superhero']) {
           return 'Your hero:' + params['superhero'];
         } else {
-          return 'You didnt chose a hero';
+          return 'You didnt choose a hero';
         }
       }
 
@@ -107,6 +107,17 @@ module.exports = [
         return null;
       }
 
+      /**
+       * Delaying the response with a specific number of milliseconds:
+       *   request.get('https://domain.example/delay_test').end(function(err, res){
+       *     console.log(res.body); // This log will be written after the delay time have passed 
+       *   })
+       */
+
+      if (match[1] === '/delay_test') {
+        context.delay = 3000; // This will delay the response by 3 seconds
+        return 'zzZ';
+      }
     },
 
     /**

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -13,7 +13,6 @@ module.exports = mock;
  */
 function mock (superagent, config, logger) {
   var Request = superagent.Request;
-  var response = {};
   var currentLog = {};
   var logEnabled = !!logger;
 
@@ -54,6 +53,7 @@ function mock (superagent, config, logger) {
     var error = null;
     var path;
     var isNodeServer = this.hasOwnProperty('cookies');
+    var response = {};
 
     if (isNodeServer) { // node server
       var originalPath = this.path;

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -142,8 +142,8 @@ function mock (superagent, config, logger) {
       }
     }
 
-    if (typeof(context.delay) === 'number') {
-      setTimeout(function() {
+    if (typeof context.delay === 'number') {
+      setTimeout(function () {
         fn(error, response);
       }, context.delay);
     }

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -106,8 +106,8 @@ function mock (superagent, config, logger) {
 
     var match = new RegExp(parser.pattern, 'g').exec(path);
 
+    var context = {};
     try {
-      var context = {};
       var fixtures = parser.fixtures(match, this._data, this.header, context);
       if (context.cancel === true) {
         return oldEnd.call(this, fn); // mocking was cancelled from within fixtures
@@ -142,7 +142,14 @@ function mock (superagent, config, logger) {
       }
     }
 
-    fn(error, response);
+    if (typeof(context.delay) === 'number') {
+      setTimeout(function() {
+        fn(error, response);
+      }, context.delay);
+    }
+    else {
+      fn(error, response);
+    }
     return this;
   };
 

--- a/tests/support/component.json
+++ b/tests/support/component.json
@@ -2,10 +2,11 @@
   "name": "superagent",
   "scripts": [
     "../../node_modules/superagent/lib/client.js",
-    "../../node_modules/superagent/lib/is-object.js",
     "../../node_modules/superagent/lib/is-function.js",
+    "../../node_modules/superagent/lib/is-object.js",
     "../../node_modules/superagent/lib/request-base.js",
     "../../node_modules/superagent/lib/response-base.js",
+    "../../node_modules/superagent/lib/should-retry.js",
     "../../node_modules/superagent/lib/utils.js"
   ],
   "main": "../../node_modules/superagent/lib/client.js",

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -181,11 +181,27 @@ module.exports = [
     }
   },
   {
-    pattern: 'https://match.toomuch.example/([\\w-]+)',
+    pattern: 'https://context.cancel.example/([\\w-]+)',
     fixtures: function (match, data, headers, context) {
       if (match && match[1] === 'real-call') {
         context.cancel = true;
       }
+      return match && match[1];
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
+  },
+  {
+    pattern: 'https://context.delay.example/([\\w-]+)',
+    fixtures: function (match, data, headers, context) {
+      context.delay = 3000;
       return match && match[1];
     },
     get: function (match, data) {


### PR DESCRIPTION
This allows delaying the response of a mock to test call pending UI changes (loaders, spinners, etc).
```
      /**
       * Delaying the response with a specific number of milliseconds:
       *   request.get('https://domain.example/delay_test').end(function(err, res){
       *     console.log(res.body); // This log will be written after the delay time have passed 
       *   })
       */

      if (match[1] === '/delay_test') {
        context.delay = 3000; // This will delay the response by 3 seconds
        return 'zzZ';
      }
```
Added a unittest for it (had to stub setTimeout).
Also, I fixed a typo in the README and renamed the domain of the cancel unittest since it was unrelated.