### PR TITLE
Add support for mocking progress events

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ module.exports = [
         context.delay = 3000; // This will delay the response by 3 seconds
         return 'zzZ';
       }
+
+      /**
+       * Mocking progress events:
+       *   request.get('https://domain.example/progress_test').end(function(err, res){
+       *     console.log(res.body); // This log will be written after all progress events emitted 
+       *   })
+       */
+
+      if (match[1] === '/progress_test') {
+        context.progress = {
+          parts: 3,               // The number of progress events to emit one after the other with linear progress
+                                  //   (Meaning, loaded will be [total/parts])
+          delay: 1000,            // [optional] The delay of emitting each of the progress events by ms 
+                                  //   (default is 0 unless context.delay specified, then it's [delay/parts])
+          total: 100,             // [optional] The total as it will appear in the progress event (default is 100)
+          lengthComputable: true, // [optional] The same as it will appear in the progress event (default is true)
+          direction: 'upload'     // [optional] superagent adds 'download'/'upload' direction to the event (default is 'upload')
+        };
+        return 'Hundred percent!';
+      }
     },
 
     /**

--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ module.exports = [
 
       /**
        * Mocking progress events:
-       *   request.get('https://domain.example/progress_test').end(function(err, res){
-       *     console.log(res.body); // This log will be written after all progress events emitted 
-       *   })
+       *   request.get('https://domain.example/progress_test')
+       *     .on('progress', function (e) { console.log(e.percent + '%'); })
+       *     .end(function(err, res){
+       *       console.log(res.body); // This log will be written after all progress events emitted 
+       *     })
        */
 
       if (match[1] === '/progress_test') {

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -181,7 +181,10 @@ function mock (superagent, config, logger) {
       }
     }
 
-    if (context.progress && (isNodeServer ? this._formData : this.hasListeners && this.hasListeners('progress'))) {
+    // Check if a callback for progress events was specified as part of the request
+    var progressEventsUsed = isNodeServer ? !!this._formData : this.hasListeners && this.hasListeners('progress');
+
+    if (context.progress && progressEventsUsed) {
       var ProgressEvent = global.ProgressEvent || function (type, rest) { // polyfill
           rest.type = type;
           return rest;
@@ -193,8 +196,7 @@ function mock (superagent, config, logger) {
       handleProgress(ProgressEvent, this, context.progress, context.progress.parts - 1, function () {
         fn(error, response);
       });
-    }
-    else if (context.delay) {
+    } else if (context.delay) {
       setTimeout(function () {
         fn(error, response);
       }, context.delay);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -47,6 +47,45 @@ function mock (superagent, config, logger) {
   }();
 
   /**
+   * Chains progrss events and eventually returns the response
+   * @param ProgressEvent (object/function) the ProgressEvent implementation
+   * @param request (object) the current request
+   *
+   * @param progress (object) the progress configuration
+   * @param progress.parts (number)
+   * @param progress.delay (number)
+   * @param progress.total (number)
+   * @param progress.lengthComputable (boolean)
+   * @param progress.direction (string)
+   *
+   * @param remainingParts (number) the remaining calls to make
+   * @param callback (function) the end response callback
+   */
+  var handleProgress = function (ProgressEvent, request, progress, remainingParts, callback) {
+    setTimeout(function () {
+      var total = progress.total || 100;
+      var loaded = total * (progress.parts - remainingParts) / progress.parts;
+      var lengthComputable = typeof progress.lengthComputable !== 'undefined' ? !!progress.lengthComputable : true;
+      var e = ProgressEvent.initProgressEvent
+        ? ProgressEvent.initProgressEvent('', true, false, lengthComputable, loaded, total) // IE10+
+        : new ProgressEvent('', {lengthComputable: lengthComputable, loaded: loaded, total: total});
+
+      if (e.total > 0) {
+        e.percent = e.loaded / e.total * 100;
+      }
+      e.direction = progress.direction || 'upload';
+
+      request.emit('progress', e);
+
+      if (remainingParts > 0) {
+        handleProgress(ProgressEvent, request, progress, remainingParts - 1, callback);
+      } else {
+        callback();
+      }
+    }, progress.delay || 0);
+  };
+
+  /**
    * Override end function
    */
   Request.prototype.end = function (fn) {
@@ -142,7 +181,22 @@ function mock (superagent, config, logger) {
       }
     }
 
-    if (typeof context.delay === 'number') {
+    if (typeof context.progress === 'object' && context.progress != null &&
+      typeof context.progress.parts === 'number' && context.progress.parts > 0 &&
+      ((isNodeServer && this._formData) || (!isNodeServer && this.hasListeners && this.hasListeners('progress')))
+    ) {
+      var ProgressEvent = global.ProgressEvent || function (type, rest) { // polyfill
+          rest.type = type;
+          return rest;
+      };
+      if (typeof context.progress.delay === 'undefined' && typeof context.delay === 'number') {
+        context.progress.delay = context.delay / context.progress.parts;
+      }
+      handleProgress(ProgressEvent, this, context.progress, context.progress.parts - 1, function () {
+        fn(error, response);
+      });
+    }
+    else if (typeof context.delay === 'number') {
       setTimeout(function () {
         fn(error, response);
       }, context.delay);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -66,16 +66,16 @@ function mock (superagent, config, logger) {
       var total = progress.total || 100;
       var loaded = total * (progress.parts - remainingParts) / progress.parts;
       var lengthComputable = progress.lengthComputable !== false; // default is true
-      var e = ProgressEvent.initProgressEvent
+      var event = ProgressEvent.initProgressEvent
         ? ProgressEvent.initProgressEvent('', true, false, lengthComputable, loaded, total) // IE10+
         : new ProgressEvent('', {lengthComputable: lengthComputable, loaded: loaded, total: total});
 
-      if (e.total > 0) {
-        e.percent = e.loaded / e.total * 100;
+      if (event.total > 0) {
+        event.percent = event.loaded / event.total * 100;
       }
-      e.direction = progress.direction || 'upload';
+      event.direction = progress.direction || 'upload';
 
-      request.emit('progress', e);
+      request.emit('progress', event);
 
       if (remainingParts > 0) {
         handleProgress(ProgressEvent, request, progress, remainingParts - 1, callback);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -53,10 +53,10 @@ function mock (superagent, config, logger) {
    *
    * @param progress (object) the progress configuration
    * @param progress.parts (number)
-   * @param progress.delay (number)
-   * @param progress.total (number)
-   * @param progress.lengthComputable (boolean)
-   * @param progress.direction (string)
+   * @param [progress.delay=0] (number)
+   * @param [progress.total=100] (number)
+   * @param [progress.lengthComputable=true] (boolean)
+   * @param [progress.direction='upload'] (string)
    *
    * @param remainingParts (number) the remaining calls to make
    * @param callback (function) the end response callback
@@ -65,7 +65,7 @@ function mock (superagent, config, logger) {
     setTimeout(function () {
       var total = progress.total || 100;
       var loaded = total * (progress.parts - remainingParts) / progress.parts;
-      var lengthComputable = typeof progress.lengthComputable !== 'undefined' ? !!progress.lengthComputable : true;
+      var lengthComputable = progress.lengthComputable !== false; // default is true
       var e = ProgressEvent.initProgressEvent
         ? ProgressEvent.initProgressEvent('', true, false, lengthComputable, loaded, total) // IE10+
         : new ProgressEvent('', {lengthComputable: lengthComputable, loaded: loaded, total: total});
@@ -181,22 +181,20 @@ function mock (superagent, config, logger) {
       }
     }
 
-    if (typeof context.progress === 'object' && context.progress != null &&
-      typeof context.progress.parts === 'number' && context.progress.parts > 0 &&
-      ((isNodeServer && this._formData) || (!isNodeServer && this.hasListeners && this.hasListeners('progress')))
-    ) {
+    if (context.progress && (isNodeServer ? this._formData : this.hasListeners && this.hasListeners('progress'))) {
       var ProgressEvent = global.ProgressEvent || function (type, rest) { // polyfill
           rest.type = type;
           return rest;
       };
-      if (typeof context.progress.delay === 'undefined' && typeof context.delay === 'number') {
+      // if no delay for parts was specified but an overall delay was, then divide the delay between the parts.
+      if (!context.progress.delay && context.delay) {
         context.progress.delay = context.delay / context.progress.parts;
       }
       handleProgress(ProgressEvent, this, context.progress, context.progress.parts - 1, function () {
         fn(error, response);
       });
     }
-    else if (typeof context.delay === 'number') {
+    else if (context.delay) {
       setTimeout(function () {
         fn(error, response);
       }, context.delay);

--- a/lib/superagent-mock.js
+++ b/lib/superagent-mock.js
@@ -47,7 +47,7 @@ function mock (superagent, config, logger) {
   }();
 
   /**
-   * Chains progrss events and eventually returns the response
+   * Chains progress events and eventually returns the response
    * @param ProgressEvent (object/function) the ProgressEvent implementation
    * @param request (object) the current request
    *

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -15,17 +15,6 @@ var request = component('tests/support', function (loader) {
       return require('superagent/node_modules/component-emitter');
     }
   });
-
-  loader.register('component-reduce', function () {
-    try {
-      // npm >= 3
-      return require('reduce-component');
-    } catch (e) {
-      return require('superagent/node_modules/reduce-component');
-    }
-  });
-
-  loader.loadDependency('emitter');
 });
 
 // Get the mock config and expectations

--- a/tests/support/component.json
+++ b/tests/support/component.json
@@ -10,8 +10,7 @@
     "../../node_modules/superagent/lib/utils.js"
   ],
   "main": "../../node_modules/superagent/lib/client.js",
-  "dependencies": {
-    "component/emitter": "*",
-    "component/reduce": "*"
-  }
+  "local": [
+    "component-emitter"
+  ]
 }

--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -213,5 +213,21 @@ module.exports = [
     put: function (match, data) {
       return {match: match, data: data};
     }
+  },
+  {
+    pattern: 'https://context.progress.example/([\\w-]+)',
+    fixtures: function (match, data, headers, context) {
+      context.progress = { parts: parseInt(match[1]), delay: 1000 };
+      return match && match[1];
+    },
+    get: function (match, data) {
+      return {match: match, data: data};
+    },
+    post: function (match, data) {
+      return {match: match, data: data};
+    },
+    put: function (match, data) {
+      return {match: match, data: data};
+    }
   }
 ];

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -746,7 +746,8 @@ module.exports = function (request, config, isServer) {
           });
       },
       'calling callback function after emitting progress events': function (test) {
-        var parts = 3, currentPart = 1;
+        var parts = 3;
+        var currentPart = 1;
         var currentRequest = request.put('https://context.progress.example/' + parts)
           .on('progress', function (e) {
             test.equal(e.total, 100);

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -12,7 +12,6 @@ module.exports = function (request, config, isServer) {
   var superagentPackage = require('superagent/package.json');
   var superagentUserAgentHeader = isServer ? {"User-Agent": 'node-superagent/' + superagentPackage.version} : {};
   var originalSetTimeout = setTimeout;
-  var timePassed = 0;
 
   return {
 
@@ -34,7 +33,10 @@ module.exports = function (request, config, isServer) {
       // Stub setTimeout
       Object.defineProperty(global, 'setTimeout', {
         value: function(callbackFunc, timeout) {
-          timePassed = timeout;
+          if (!global.setTimeout.calls) {
+            global.setTimeout.calls = [];
+          }
+          global.setTimeout.calls.push([callbackFunc, timeout]); // spy on calls made to setTimeout
           callbackFunc();
         }
       });
@@ -51,7 +53,6 @@ module.exports = function (request, config, isServer) {
       currentLog = null;
       // restore setTimeout
       Object.defineProperty(global, 'setTimeout', { value: originalSetTimeout });
-      timePassed = 0;
 
       go();
     },
@@ -740,9 +741,25 @@ module.exports = function (request, config, isServer) {
         request.put('https://context.delay.example/test')
           .end(function (err, result) {
             test.equal(result.data, 'test'); // just to see the arguments are passed as usual
-            test.equal(timePassed, 3000); // setTimeout has been called
+            test.equal(setTimeout.calls.length, 1); // setTimeout has been called
             test.done();
           });
+      },
+      'calling callback function after emitting progress events': function (test) {
+        var parts = 3, currentPart = 1;
+        var r = request.put('https://context.progress.example/' + parts)
+          .on('progress', function (e) {
+            test.equal(e.total, 100);
+            test.equal(e.loaded, (100 / parts) * currentPart++);
+          });
+        if (isServer) {
+          r = r.field('name','val'); // force creation of formData (the only case where progress is used on node)
+        }
+        r.end(function (err, result) {
+          test.equal(result.data, parts); // just to see the arguments are passed as usual
+          test.equal(setTimeout.calls.length, parts); // setTimeout has been called as the number of parts
+          test.done();
+        });
       }
     },
     'Logger': {

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -747,15 +747,16 @@ module.exports = function (request, config, isServer) {
       },
       'calling callback function after emitting progress events': function (test) {
         var parts = 3, currentPart = 1;
-        var r = request.put('https://context.progress.example/' + parts)
+        var currentRequest = request.put('https://context.progress.example/' + parts)
           .on('progress', function (e) {
             test.equal(e.total, 100);
             test.equal(e.loaded, (100 / parts) * currentPart++);
           });
         if (isServer) {
-          r = r.field('name','val'); // force creation of formData (the only case where progress is used on node)
+          // force creation of formData (the only case where progress is used on node)
+          currentRequest = currentRequest.field('name','val');
         }
-        r.end(function (err, result) {
+        currentRequest.end(function (err, result) {
           test.equal(result.data, parts); // just to see the arguments are passed as usual
           test.equal(setTimeout.calls.length, parts); // setTimeout has been called as the number of parts
           test.done();


### PR DESCRIPTION

This adds support for mocking progress events as used with superagent.
(unit test added)
```js
      /**
       * Mocking progress events:
       *   request.get('https://domain.example/progress_test')
       *     .on('progress', function (e) { console.log(e.percent + '%'); })
       *     .end(function(err, res){
       *       console.log(res.body); // This log will be written after all progress events emitted 
       *     })
       */

      if (match[1] === '/progress_test') {
        context.progress = {
          parts: 3,               // The number of progress events to emit one after the other with linear progress
                                  //   (Meaning, loaded will be [total/parts])
          delay: 1000,            // [optional] The delay of emitting each of the progress events by ms 
                                  //   (default is 0 unless context.delay specified, then it's [delay/parts])
          total: 100,             // [optional] The total as it will appear in the progress event (default is 100)
          lengthComputable: true, // [optional] The same as it will appear in the progress event (default is true)
          direction: 'upload'     // [optional] superagent adds 'download'/'upload' direction to the event (default is 'upload')
        };
        return 'Hundred percent!';
      }
```