### PR TITLE
Fix test config

### DIFF
--- a/.jestrc
+++ b/.jestrc
@@ -1,5 +1,0 @@
-{
-  "transform": {
-    "^.+\\.js$": "babel-jest"
-  }
-}  

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -40,7 +40,7 @@ module.exports = function (request, config, isServer) {
     });
 
     // Init module
-    superagentMock = require('./../../lib/superagent-mock')(request, config, logger);
+    superagentMock = require('./../../src/superagent-mock')(request, config, logger);
 
     go();
   });


### PR DESCRIPTION
- Jest does not use .jestrc and uses babel-jest by default (transform `^.+\\.jsx?$`)
- load superagent-mock from src/ since lib/ is our build folder
