### PR TITLE
Remove abort mock (checked on superagent). Add .idea to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 lib
 es
+.idea

--- a/src/superagent-mock.js
+++ b/src/superagent-mock.js
@@ -13,7 +13,6 @@ module.exports = function (superagent, config, logger) {
    * Keep the default methods
    */
   const oldEnd = Request.prototype.end;
-  const oldAbort = Request.prototype.abort;
 
   /**
    * Flush the current log in the logger method and reset it
@@ -200,16 +199,9 @@ module.exports = function (superagent, config, logger) {
     return this;
   };
 
-  Request.prototype.abort = function () {
-    this.xhr = this.req = {abort: function () {}};
-
-    return oldAbort.call(this);
-  };
-
   return {
     unset: function () {
       Request.prototype.end = oldEnd;
-      Request.prototype.abort = oldAbort;
     }
   };
 };


### PR DESCRIPTION
Since **superagent** checks for the availability of `this.xhr` & `this.req` the mocking is no longer needed.

```js
RequestBase.prototype.abort = function(){
  if (this._aborted) {
    return this;
  }
  this._aborted = true;
  this.xhr && this.xhr.abort(); // browser
  this.req && this.req.abort(); // node
  this.clearTimeout();
  this.emit('abort');
  return this;
};
```

Also add `.idea` to `.gitignore` pretty much standard this days, and I like working with IntelliJ IDE.