### PR TITLE
Add support for superagent .ok() hook

### DIFF
--- a/tests/support/config.js
+++ b/tests/support/config.js
@@ -9,13 +9,13 @@ module.exports = [
       return 'Fixture !';
     },
     get: function (match, data) {
-      return {match: match, data: data, code: 200};
+      return {match: match, data: data, code: 200, status: 200};
     },
     post: function (match, data) {
-      return {match: match, data: data, code: 201};
+      return {match: match, data: data, code: 201, status: 201};
     },
     put: function (match, data) {
-      return {match: match, data: data, code: 201};
+      return {match: match, data: data, code: 201, status: 201};
     }
   },
   {

--- a/tests/support/expectations.js
+++ b/tests/support/expectations.js
@@ -718,6 +718,78 @@ module.exports = function (request, config, isServer) {
       done();
     });
 
+    it('called ok() callback', function (done) {
+      var okCalled = false;
+      request.get('https://domain.example/test')
+        .ok(function() {
+          okCalled = true;
+          return true;
+        })
+        .end(function(err, result){
+          expect(okCalled).toBe(true);
+          expect(!err).toBe(true);
+          expect(result.data).toBe('Fixture !');
+          done();
+        });
+    });
+
+    it('called ok() callback and handled a false return', function (done) {
+      var okCalled = false;
+      request.get('https://domain.example/test')
+        .ok(function() {
+          okCalled = true;
+          return false;
+        })
+        .end(function(err, result){
+          expect(okCalled).toBe(true);
+          expect(err).not.toBe(null);
+          expect(result.data).toBe('Fixture !');
+          done();
+        });
+    });
+
+    it('called ok() callback and handled an exception', function (done) {
+      var okCalled = false;
+      request.get('https://domain.example/test')
+        .ok(function() {
+          okCalled = true;
+          throw new Error('boom')
+        })
+        .end(function(err, result){
+          expect(okCalled).toBe(true);
+          expect(err).not.toBe(null);
+          expect(!result).toBe(false);
+          done();
+        });
+    });
+
+    it('did not call ok() callback without status', function (done) {
+      var okCalled = false;
+      request.get('https://callback.method.example')
+        .ok(function() {
+          okCalled = true;
+          return true;
+        })
+        .end(function(err, result){
+          expect(!err).toBe(true);
+          expect(okCalled).toBe(false);
+          expect(result.data).toBe('Fixture !');
+          done();
+        });
+    });
+
+    it('should not have an error when .ok() allows it', function (done) {
+      request.get('https://error.example/401')
+        .ok(function(res) {
+          return res.status === 401;
+        })
+        .end(function(err, result){
+          expect(!err).toBe(true);
+          expect(result).not.toBe(null);
+          done();
+        });
+    });
+
     it('is only called once', function (done) {
       var calls = 0;
       expect(function() {


### PR DESCRIPTION
Superagent has a hook to allow for the response object to be checked before determining if the request should fail or succeed.  Currently superagent-mock is not executing this callback which causes tests to fail.

Superagent-mock doesn't normally set a status code for normal responses but the .ok() hook does require the status property.  I kinda wonder if it would make to switch to using 'status' instead of 'code' in the documentation and tests.  Not sure if or how this could be documented.