### PR TITLE
update travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
-  - '4'
-  - '5'
   - '6'
   - '7'
-script: npm install superagent@3.* && npm run lint && npm test
+  - '8'
+  - '9'
+script:
+  - yarn add superagent@~3.6.0 && yarn ci
+  - yarn add superagent@~3.7.0 && yarn ci
+  - yarn add superagent@~3.8.0 && yarn ci

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Install with [npm](http://npmjs.org/): `npm install superagent-mock`
 
 Install with [yarn](https://yarnpkg.com/): `yarn add superagent-mock`
 
+## Requirements
+
+node >= 6
+superagent >= ^3.6.0
+
 ## Usage
 
 First, you have to define the URLs to mock in a configuration file:

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "superagent": "^3.6.0"
   },
   "scripts": {
+    "ci": "yarn clean && yarn lint && yarn build && yarn test",
     "clean": "rimraf lib es",
     "test": "jest tests",
     "lint": "eslint src tests",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build": "yarn build:commonjs && yarn build:es",
-    "prepublish": "yarn run clean && yarn lint && yarn build"
+    "prepublishOnly": "yarn ci"
   }
 }


### PR DESCRIPTION
- add node 8 & 9 on Travis
-  remove node 4 & node 5: `yarn add superagent@3.6.3` on node < 6 failed because its dependency node-mime required node >= 6
- test explicit last patch versions of superagent on Travis
- remove `prepublish` which is executed on `yarn install`, `prepublishOnly` instead