### PR TITLE
superagent peerDep >=3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/M6Web/superagent-mock"
   },
   "peerDependencies": {
-    "superagent": "^3.6.0"
+    "superagent": ">=3.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.4",


### PR DESCRIPTION
This will prevent warnings in the console for versions of superagent >=4.0.0