### PR TITLE
Feature/add typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "main": "lib/superagent-mock.js",
   "module": "es/superagent-mock.js",
+  "types": "types/superagent-mock.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/M6Web/superagent-mock"

--- a/types/superagent-mock.d.ts
+++ b/types/superagent-mock.d.ts
@@ -1,0 +1,79 @@
+declare module 'superagent-mock' {
+  import superagent from 'superagent';
+
+  export type Method = 'head' | 'get' | 'post' | 'put' | 'delete';
+
+  export type AnyValue =
+    | string
+    | string[]
+    | number
+    | number[]
+    | boolean
+    | boolean[]
+    | ObjectLiteral
+    | ObjectLiteral[];
+
+  interface ObjectLiteral {
+    [key: string]: AnyValue;
+    [key: number]: AnyValue;
+  }
+
+  export type RequestBody = ObjectLiteral;
+  export type Response = Fixture | ObjectLiteral;
+  export type Fixture = AnyValue;
+
+  export interface Context {
+    method: Method;
+    cancel?: boolean;
+    delay?: number;
+    progress?: {
+      parts: number;
+      delay?: number;
+      total?: number;
+      lengthComputable?: boolean;
+      direction?: 'upload' | string;
+    };
+  }
+
+  type ParserMethods = {
+    [key in Method]?: (
+      match: RegExpExecArray,
+      fixtures: ReturnType<Config['fixtures']>
+    ) => Response;
+  };
+
+  export type Config = ParserMethods & {
+    pattern: string;
+
+    fixtures(
+      match: RegExpExecArray,
+      reqBody: RequestBody,
+      headers: { [key: string]: string },
+      context: Context
+    ): Fixture | null | undefined;
+  };
+
+  export interface Log {
+    matcher: string;
+    mocked: boolean;
+    url: string;
+    method: Method;
+    data: ObjectLiteral;
+    headers: { [key: string]: string };
+    timestamp: number;
+  }
+
+  export type Logger = (log: Log) => void;
+
+  export interface TearDown {
+    unset(): void;
+  }
+
+  function initialise(
+    sa: typeof superagent,
+    configs: Config[],
+    logger?: Logger
+  ): TearDown;
+
+  export default initialise;
+}


### PR DESCRIPTION
**Why:**
(Hi!) We've been using your wonderful module in a Front-End project that uses Typescript and to make things clearer for the devs (IDE intellisense) we wrote custom declaration files for it and included in the project itself. Although that works perfectly for us, we thought it might benefit others too, hence this PR.

**How:**
Given the fact that the module itself is written in JavaScript, we cannot automatically generate the declaration file. This means we wrote it manually my cross-referencing documentation and source code. Any updates to the module should be reflected in the declaration files as well to keep them up to date.

**Need help:**
Although I am comfortable writing Typescript, I'm by no means an expert at it, so I invite the community to improve my work.
One idea for the future would be to make to extend the `Config` interface by making it a generic interface, therefore Typescript could infer the return type of the `fixtures` method based on the request method.

**Screenshots:**
<img width="987" alt="Screenshot 2020-06-05 at 15 06 34" src="https://user-images.githubusercontent.com/5981528/83885494-58550800-a73e-11ea-8085-7dc857ae41e1.png">
<img width="984" alt="Screenshot 2020-06-05 at 15 06 52" src="https://user-images.githubusercontent.com/5981528/83885502-5ab76200-a73e-11ea-9011-7163cae43c3e.png">
<img width="958" alt="Screenshot 2020-06-05 at 15 07 05" src="https://user-images.githubusercontent.com/5981528/83885505-5b4ff880-a73e-11ea-8768-dcdedf5b38c2.png">

